### PR TITLE
[chore] Use next/link in ModuleListSidebar

### DIFF
--- a/www/components/ModuleListSidebar.tsx
+++ b/www/components/ModuleListSidebar.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 
+import NextLink from "next/link";
 import { Box } from "@welcome-ui/box";
 import { Text } from "@welcome-ui/text";
 import { Link } from "@welcome-ui/link";
@@ -7,7 +8,7 @@ import styled from "styled-components";
 
 import { Pkg } from "../lib/docs";
 
-const ModuleLink = styled(Link)<{ active: boolean }>`
+const StyledWUILink = styled(Link)<{ active: boolean }>`
   padding-left: ${(props) => props.theme.space.xs};
   padding-right: ${(props) => props.theme.space.md};
   width: 100%;
@@ -19,6 +20,12 @@ const ModuleLink = styled(Link)<{ active: boolean }>`
     color: ${props.theme.colors.dark["900"]};
   `}
 `;
+
+const ModuleLink = ({ children, href, active, ...rest }) => (
+  <NextLink href={href} passHref {...rest}>
+    <StyledWUILink active={active}>{children}</StyledWUILink>
+  </NextLink>
+);
 
 interface ModuleListSidebarProps {
   pkg: Pkg;

--- a/www/pages/index.tsx
+++ b/www/pages/index.tsx
@@ -1,7 +1,6 @@
 import Head from "next/head";
 import Link from "next/link";
 import React from "react";
-import { LightAsync as SyntaxHighlighter } from "react-syntax-highlighter";
 
 import { createTheme, WuiProvider } from "@welcome-ui/core";
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #14
* #13
* #12
* __->__ #11

Without this, each click triggered a page reload. Now we do smart NextJS
things instead.