### PR TITLE
[chore] Fix some "duplicate key" warnings

### DIFF
--- a/www/components/Class.tsx
+++ b/www/components/Class.tsx
@@ -20,8 +20,8 @@ function Methods({ cls }: Props) {
   return (
     <>
       <Text variant="h5">Methods</Text>
-      {cls.methods.map((method) => (
-        <Function key={method.name} func={method} />
+      {cls.methods.map((method, index) => (
+        <Function key={`${method.name}/${index}`} func={method} />
       ))}
     </>
   );

--- a/www/components/Intersperse.tsx
+++ b/www/components/Intersperse.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 
 interface Props {
-  separator: React.ReactNode | string;
+  separator: ((key: string) => React.ReactNode) | string;
   children: React.ReactNode[];
 }
 
@@ -10,7 +10,11 @@ export default function Intersperse({ separator, children }: Props) {
   const childrenWithSeparators: React.ReactNode[] = [];
   for (let i = 0; i < childrenCount; i++) {
     if (i > 0) {
-      childrenWithSeparators.push(separator);
+      if (typeof separator === "function") {
+        childrenWithSeparators.push(separator(i.toString()));
+      } else {
+        childrenWithSeparators.push(separator);
+      }
     }
     childrenWithSeparators.push(children[i]);
   }

--- a/www/components/ModuleListSidebar.tsx
+++ b/www/components/ModuleListSidebar.tsx
@@ -42,7 +42,6 @@ export default function ModuleListSidebar({
       {pkg.modules.map((mod) => (
         <Text key={mod.name}>
           <ModuleLink
-            key={mod.name}
             href={`/${pkg.name}/${mod.name}`}
             active={mod.name === currentModule}
           >

--- a/www/pages/[...pkg].tsx
+++ b/www/pages/[...pkg].tsx
@@ -87,7 +87,7 @@ function Content(pkg: Pkg, symbol: string) {
       <Text>{mod.documentation}</Text>
       <Box>
         <Text variant="h3">Classes</Text>
-        <Intersperse separator={<hr />}>
+        <Intersperse separator={(key) => <hr key={key} />}>
           {mod.classes.map((cls) => (
             <Class key={cls.name} cls={cls} />
           ))}
@@ -96,15 +96,15 @@ function Content(pkg: Pkg, symbol: string) {
       <hr />
       <Box>
         <Text variant="h3">Functions</Text>
-        {mod.functions.map((fn) => (
-          <Function func={fn} key={fn.name}></Function>
+        {mod.functions.map((fn, index) => (
+          <Function func={fn} key={`${fn.name}/${index}`}></Function>
         ))}
       </Box>
       <hr />{" "}
       <Box>
         <Text variant="h3">Variables</Text>
-        {mod.variables.map((v) => (
-          <Text key={v.name}>{v.name}</Text>
+        {mod.variables.map((v, index) => (
+          <Text key={`${v.name}/${index}`}>{v.name}</Text>
         ))}
       </Box>
     </Wrapper>


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #14
* #13
* __->__ #12
* #11

* The duplicate variables are weird, probably problems in the indexer;
  whatevs, shouldn't cause warnings on the frontend.
* Duplicate methods are valid because overloading; I failed to find a
  stable ID, so just used the `index`, acknowledging that this is a bad
  practice