### PR TITLE
Increased largePageDataBytes threshold

### DIFF
--- a/www/next.config.js
+++ b/www/next.config.js
@@ -1,10 +1,13 @@
 /** @type {import('next').NextConfig} */
 
 const nextConfig = {
-    reactStrictMode: true,
-    compiler: {
-      styledComponents: true,
-    },
-  }
-  
-  module.exports = nextConfig
+  reactStrictMode: true,
+  compiler: {
+    styledComponents: true,
+  },
+  experimental: {
+    largePageDataBytes: 1024 * 1024,
+  },
+};
+
+module.exports = nextConfig;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #14
* #13
* #12
* #11

Before this change, we'd get lots of warnings about the data in
`getStaticProps` being too large
(https://nextjs.org/docs/messages/large-page-data). After thinking about
it a bit: documentation for a module is sometimes going to be large,
that's life. If / once we refactor the page structure this may get
better, but even then, documentation for a _class_ can be big. And
that's OK.