### PR TITLE
fix: Remove duplicate modules from index

### DIFF
--- a/py_wtf/cli/__init__.py
+++ b/py_wtf/cli/__init__.py
@@ -77,6 +77,10 @@ def index_dir_cmd(dir: str) -> None:
 
 
 def index_dir(dir: Path) -> Iterable[Module]:
+    # TODO: do something with .pyi files
+    # If there's a .pyi file with no corresponding .py -> just index .pyi
+    # If both of them exist, do a best effort merge? 🤷
+    trailrunner.core.INCLUDE_PATTERN = r".+\.py$"
     for (_, mod) in trailrunner.run_iter(
         paths=trailrunner.walk(dir), func=partial(index_file, dir)
     ):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)

When both `.py` and `.pyi` files exist for the same module, the indexer would crawl both, resulting in the same module appearing twice in the index.
We should be smarter about this in the future, but for now just don't index `.pyi` files

Test Plan:
Tested on `more_itertools`