### PR TITLE
Switch to client-side rendering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-index/
+www/public/_index/
 node_modules/
 www/.next/
 __pycache__/

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Please do. Python 3.10, Node 16.14.
 cd py.wtf
 pipx run hatch shell
 YOUR_FAVORITE_PACKAGE=click
-py-wtf index --package-name $YOUR_FAVORITE_PACKAGE index/
+py-wtf index --package-name $YOUR_FAVORITE_PACKAGE www/public/_index/
 cd www
 npm install
 npm run dev

--- a/publish.sh
+++ b/publish.sh
@@ -12,7 +12,7 @@ if ! which hatch &>/dev/null; then
 fi
 
 for pkg in click aioitertools aiomultiprocessing more_itertools usort ufmt black libcst; do
-  hatch run py-wtf index --package-name="$pkg" index/
+  hatch run py-wtf index --package-name="$pkg" www/public/_index/
 done
 
 cd "$TOPLEVEL/www"

--- a/www/components/Docs/Module.tsx
+++ b/www/components/Docs/Module.tsx
@@ -6,7 +6,7 @@ import * as docs from "@/lib/docs";
 import * as url from "@/lib/url";
 
 import Documentation from "./Documentation";
-import SymbolLinkTable, { Sym } from "./SymbolLinkTable";
+import SymbolLinkTable from "./SymbolLinkTable";
 
 interface Props {
   pkg: docs.Pkg;

--- a/www/components/FetchPackage.tsx
+++ b/www/components/FetchPackage.tsx
@@ -1,0 +1,32 @@
+import { Box } from "@welcome-ui/box";
+import React from "react";
+import useSWR from "swr";
+
+import * as docs from "@/lib/docs";
+import * as url from "@/lib/url";
+
+const fetcher = (input: RequestInfo | URL, init?: RequestInit) =>
+  fetch(input, init).then((res) => res.json());
+
+interface Props {
+  name?: string;
+  content: (pkg: docs.Pkg) => React.ReactElement;
+}
+
+export default function FetchPackage({ name, content }: Props) {
+  if (name === undefined) {
+    return null;
+  }
+  const pkgJsonUrl = url.pkgJson(name);
+  const { data, error } = useSWR<docs.Pkg, Error>(pkgJsonUrl, fetcher);
+
+  if (error)
+    return (
+      <Box>
+        Failed to load <code>{pkgJsonUrl}</code>: {error.message}
+      </Box>
+    );
+  if (!data) return <Box>Loading...</Box>;
+
+  return content(data);
+}

--- a/www/components/Sidebar/ModuleList.tsx
+++ b/www/components/Sidebar/ModuleList.tsx
@@ -7,7 +7,7 @@ import SidebarLinkList from "./SidebarLinkList";
 
 interface Props {
   pkg: Pkg;
-  currentModule: Module;
+  currentModule?: Module;
 }
 
 export default function ModuleList({ pkg, currentModule }: Props) {
@@ -15,7 +15,7 @@ export default function ModuleList({ pkg, currentModule }: Props) {
     <SidebarLinkList
       title="Modules"
       items={pkg.modules}
-      active={currentModule.name}
+      active={currentModule?.name}
       url={url.mod.bind(null, pkg)}
     />
   );

--- a/www/lib/docs.ts
+++ b/www/lib/docs.ts
@@ -1,13 +1,17 @@
-import fs from "fs";
+import { promises as fs } from "fs";
 import path from "path";
 
 const indexDirectory = path.join(process.cwd(), "..", "index");
 
-export function getPackageIndex(): Pkg[] {
-  const fileNames = fs
-    .readdirSync(indexDirectory)
-    .filter((fname) => fname.endsWith(".json"));
-  return fileNames.map((fname) => getPackage(fname.replace(/.json$/, "")));
+export async function listPackages(): Promise<string[]> {
+  const entries = await fs.readdir(indexDirectory);
+  const fileNames = entries.filter((fname) => fname.endsWith(".json"));
+  return fileNames.map((f) => f.replace(/\.json$/, ""));
+}
+
+export async function readPackageJson(name: string): Promise<string> {
+  const indexFile = path.join(indexDirectory, `${name}.json`);
+  return await fs.readFile(indexFile, "utf8");
 }
 
 export type Pkg = {
@@ -57,10 +61,3 @@ export type Class = {
   inner_classes: Array<Class>;
   documentation: Array<Documentation>;
 };
-
-export function getPackage(name: string): Pkg {
-  const indexFile = path.join(indexDirectory, `${name}.json`);
-  const indexData = fs.readFileSync(indexFile, "utf8");
-  const index: Pkg = JSON.parse(indexData) as Pkg;
-  return index;
-}

--- a/www/lib/docs.ts
+++ b/www/lib/docs.ts
@@ -1,7 +1,7 @@
 import { promises as fs } from "fs";
 import path from "path";
 
-const indexDirectory = path.join(process.cwd(), "..", "index");
+const indexDirectory = path.join(process.cwd(), "public", "_index");
 
 export async function listPackages(): Promise<string[]> {
   const entries = await fs.readdir(indexDirectory);
@@ -9,9 +9,10 @@ export async function listPackages(): Promise<string[]> {
   return fileNames.map((f) => f.replace(/\.json$/, ""));
 }
 
-export async function readPackageJson(name: string): Promise<string> {
+export async function getPackage(name: string): Promise<Pkg> {
   const indexFile = path.join(indexDirectory, `${name}.json`);
-  return await fs.readFile(indexFile, "utf8");
+  const json = await fs.readFile(indexFile, "utf8");
+  return JSON.parse(json) as Pkg;
 }
 
 export type Pkg = {

--- a/www/lib/url.ts
+++ b/www/lib/url.ts
@@ -9,6 +9,10 @@ export function withoutPrefix(prefix: string, s: string) {
   return s;
 }
 
+export function pkgJson(name: string): string {
+  return `/_index/${name}.json`;
+}
+
 export function pkg(p: docs.Pkg): UrlObject {
   return {
     pathname: "/[pkg]",

--- a/www/package-lock.json
+++ b/www/package-lock.json
@@ -34,6 +34,7 @@
         "eslint-config-prettier": "^8.5.0",
         "eslint-import-resolver-typescript": "^3.4.0",
         "eslint-plugin-import": "^2.26.0",
+        "swr": "^1.3.0",
         "typescript": "^4.7.4"
       }
     },
@@ -4502,6 +4503,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/swr": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/swr/-/swr-1.3.0.tgz",
+      "integrity": "sha512-dkghQrOl2ORX9HYrMDtPa7LTVHJjCTeZoB1dqTbnnEDlSvN8JEKpYIYurDfvbQFUUS8Cg8PceFVZNkW0KNNYPw==",
+      "dev": true,
+      "peerDependencies": {
+        "react": "^16.11.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/synckit": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.8.2.tgz",
@@ -7926,6 +7936,13 @@
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
       "dev": true
+    },
+    "swr": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/swr/-/swr-1.3.0.tgz",
+      "integrity": "sha512-dkghQrOl2ORX9HYrMDtPa7LTVHJjCTeZoB1dqTbnnEDlSvN8JEKpYIYurDfvbQFUUS8Cg8PceFVZNkW0KNNYPw==",
+      "dev": true,
+      "requires": {}
     },
     "synckit": {
       "version": "0.8.2",

--- a/www/package.json
+++ b/www/package.json
@@ -21,7 +21,8 @@
     "react": "^17.0.2",
     "react-dom": "17.0.2",
     "react-syntax-highlighter": "^15.5.0",
-    "styled-components": "^5.3.5"
+    "styled-components": "^5.3.5",
+    "swr": "^1.3.0"
   },
   "devDependencies": {
     "@next/eslint-plugin-next": "^12.2.4",

--- a/www/pages/[pkg].tsx
+++ b/www/pages/[pkg].tsx
@@ -1,42 +1,19 @@
-import { GetStaticPaths, GetStaticProps } from "next";
+import { useRouter } from "next/router";
 
 import Package from "@/components/Docs/Package";
+import FetchPackage from "@/components/FetchPackage";
 import Layout from "@/components/Layout";
 
-import { Pkg, getPackage, getPackageIndex } from "@/lib/docs";
-
-export const getStaticProps: GetStaticProps<Props> = ({ params }) => {
-  if (
-    params === undefined ||
-    params.pkg === undefined ||
-    typeof params.pkg !== "string"
-  ) {
-    return { notFound: true };
-  }
-  const pkg = getPackage(params.pkg);
-  return {
-    props: {
-      pkg: pkg,
-    },
-  };
-};
-
-export const getStaticPaths: GetStaticPaths = () => {
-  const idx = getPackageIndex();
-  return {
-    paths: idx.map((pkg) => ({ params: { pkg: pkg.name } })),
-    fallback: false,
-  };
-};
-
-interface Props {
-  pkg: Pkg;
-}
-
-export default function PackagePage({ pkg }: Props) {
+export default function PackagePage() {
+  const router = useRouter();
   return (
-    <Layout pkg={pkg}>
-      <Package pkg={pkg} />
-    </Layout>
+    <FetchPackage
+      name={router.query.pkg as string}
+      content={(pkg) => (
+        <Layout pkg={pkg}>
+          <Package pkg={pkg} />
+        </Layout>
+      )}
+    />
   );
 }

--- a/www/pages/[pkg]/[mod].tsx
+++ b/www/pages/[pkg]/[mod].tsx
@@ -22,7 +22,7 @@ export default function ModulePage() {
             {mod ? (
               <Module pkg={pkg} mod={mod} />
             ) : (
-              `Module ${modName} not found :O`
+              `Module ${modName} not found 🤪`
             )}
           </Layout>
         );

--- a/www/pages/[pkg]/[mod].tsx
+++ b/www/pages/[pkg]/[mod].tsx
@@ -1,55 +1,32 @@
-import { GetStaticPaths, GetStaticProps } from "next";
+import { useRouter } from "next/router";
 
 import Module from "@/components/Docs/Module";
+import FetchPackage from "@/components/FetchPackage";
 import Layout from "@/components/Layout";
 import ModuleList from "@/components/Sidebar/ModuleList";
 
-import * as docs from "@/lib/docs";
-
-interface Props {
-  pkg: docs.Pkg;
-  mod: docs.Module;
-}
-
-export const getStaticProps: GetStaticProps<Props> = ({ params }) => {
-  if (
-    params === undefined ||
-    params.pkg === undefined ||
-    typeof params.pkg !== "string" ||
-    params.mod === undefined ||
-    typeof params.mod !== "string"
-  ) {
-    return { notFound: true };
-  }
-  const pkg = docs.getPackage(params.pkg);
-  const mod = pkg.modules.find((m) => m.name === params.mod);
-  if (mod === undefined) {
-    return { notFound: true };
-  }
-  return {
-    props: {
-      pkg,
-      mod,
-    },
-  };
-};
-
-export const getStaticPaths: GetStaticPaths = () => {
-  const idx = docs.getPackageIndex();
-  return {
-    paths: idx.flatMap((pkg) =>
-      pkg.modules.map((mod) => ({
-        params: { pkg: pkg.name, mod: mod.name },
-      }))
-    ),
-    fallback: false,
-  };
-};
-
-export default function ModulePage({ pkg, mod }: Props) {
+export default function ModulePage() {
+  const router = useRouter();
+  const pkgName = router.query.pkg as string;
+  const modName = router.query.mod as string;
   return (
-    <Layout pkg={pkg} sidebar={<ModuleList pkg={pkg} currentModule={mod} />}>
-      <Module pkg={pkg} mod={mod} />
-    </Layout>
+    <FetchPackage
+      name={pkgName}
+      content={(pkg) => {
+        const mod = pkg.modules.find((mod) => mod.name === modName);
+        return (
+          <Layout
+            pkg={pkg}
+            sidebar={<ModuleList pkg={pkg} currentModule={mod} />}
+          >
+            {mod ? (
+              <Module pkg={pkg} mod={mod} />
+            ) : (
+              `Module ${modName} not found :O`
+            )}
+          </Layout>
+        );
+      }}
+    />
   );
 }

--- a/www/pages/[pkg]/[mod]/[symbol].tsx
+++ b/www/pages/[pkg]/[mod]/[symbol].tsx
@@ -1,186 +1,89 @@
-import { GetStaticPaths, GetStaticProps } from "next";
+import { useRouter } from "next/router";
 
 import Class from "@/components/Docs/Class";
 import Function from "@/components/Docs/Function";
 import Variable from "@/components/Docs/Variable";
+import FetchPackage from "@/components/FetchPackage";
 import Layout from "@/components/Layout";
 import ClassContents from "@/components/Sidebar/ClassContents";
 import ModuleContents from "@/components/Sidebar/ModuleContents";
+import ModuleList from "@/components/Sidebar/ModuleList";
 
-import * as docs from "@/lib/docs";
 import { withoutPrefix } from "@/lib/url";
 
-type Sym =
-  | { kind: "class"; symbol: docs.Class }
-  | { kind: "function"; symbol: docs.Func }
-  | { kind: "variable"; symbol: docs.Variable };
-
-interface Props {
-  pkg: docs.Pkg;
-  mod: docs.Module;
-  symbol: Sym;
-}
-
-type MaybeSym = {
-  kind: Sym["kind"];
-  symbol: Sym["symbol"] | undefined;
-};
-
-function coalesceSymbol(...xs: MaybeSym[]): Sym | undefined {
-  for (const x of xs) {
-    if (x.symbol) {
-      // This is cheating, but I don't know how to do this without cheating in the TS type system
-      return x as Sym;
-    }
-  }
-}
-
-export const getStaticProps: GetStaticProps<Props> = ({ params }) => {
-  if (
-    params === undefined ||
-    params.pkg === undefined ||
-    typeof params.pkg !== "string" ||
-    params.mod == undefined ||
-    typeof params.mod !== "string" ||
-    params.symbol == undefined ||
-    typeof params.symbol !== "string"
-  ) {
-    return { notFound: true };
-  }
-  const pkg = docs.getPackage(params.pkg);
-
-  const mod = pkg.modules.find((m) => m.name === params.mod);
-  if (mod === undefined) {
-    return { notFound: true };
-  }
-
-  const find = <T extends { name: string }>(xs: T[]): T | undefined => {
-    return xs.find((x) => x.name === `${mod.name}.${params.symbol as string}`);
-  };
-
-  const sym = coalesceSymbol(
-    {
-      kind: "class",
-      symbol: find(mod.classes),
-    },
-    {
-      kind: "function",
-      symbol: find(mod.functions),
-    },
-    {
-      kind: "variable",
-      symbol: find(mod.variables),
-    }
-  );
-  if (sym === undefined) {
-    return { notFound: true };
-  }
-
-  return {
-    props: {
-      pkg,
-      mod,
-      symbol: sym,
-    },
-  };
-};
-
-export const getStaticPaths: GetStaticPaths = () => {
-  const idx = docs.getPackageIndex();
-
-  const paths: { params: { pkg: string; mod: string; symbol: string } }[] = [];
-  function pushParams(
-    pkg: docs.Pkg,
-    mod: docs.Module,
-    thing: docs.Class | docs.Func | docs.Variable
-  ) {
-    paths.push({
-      params: {
-        pkg: pkg.name,
-        mod: mod.name,
-        symbol: withoutPrefix(mod.name, thing.name),
-      },
-    });
-  }
-
-  idx.forEach((pkg) => {
-    pkg.modules.forEach((mod) => {
-      mod.classes.forEach((cls) => pushParams(pkg, mod, cls));
-      mod.functions.forEach((fn) => pushParams(pkg, mod, fn));
-      mod.variables.forEach((v) => pushParams(pkg, mod, v));
-    });
-  });
-
-  return {
-    paths,
-    fallback: false,
-  };
-};
-
-export default function Page({ pkg, mod, symbol }: Props) {
-  const Sidebar = (() => {
-    switch (symbol.kind) {
-      case "class":
-        return (
-          <>
-            <ClassContents
-              pkg={pkg}
-              mod={mod}
-              cls={symbol.symbol}
-              currentSymbol=""
-            />
-            <ModuleContents pkg={pkg} mod={mod} currentSymbol="" />
-          </>
-        );
-      case "function":
-        return (
-          <ModuleContents
-            pkg={pkg}
-            mod={mod}
-            currentSymbol={symbol.symbol.name}
-          />
-        );
-      case "variable":
-        return (
-          <ModuleContents
-            pkg={pkg}
-            mod={mod}
-            currentSymbol={symbol.symbol.name}
-          />
-        );
-    }
-  })();
-
-  const Content = (() => {
-    switch (symbol.kind) {
-      case "class":
-        return <Class cls={symbol.symbol} />;
-      case "function":
-        return (
-          <>
-            {mod.functions
-              .filter((f) => f.name === symbol.symbol.name)
-              .map((f) => (
-                <Function func={f} />
-              ))}
-          </>
-        );
-      case "variable":
-        return (
-          <>
-            {mod.variables
-              .filter((v) => v.name === symbol.symbol.name)
-              .map((v) => (
-                <Variable variable={v} />
-              ))}
-          </>
-        );
-    }
-  })();
-
+export default function ModulePage() {
+  const router = useRouter();
+  const pkgName = router.query.pkg as string;
+  const modName = router.query.mod as string;
+  const symName = router.query.symbol as string;
   return (
-    <Layout pkg={pkg} sidebar={Sidebar}>
-      {Content}
-    </Layout>
+    <FetchPackage
+      name={pkgName}
+      content={(pkg) => {
+        const [Sidebar, Content] = (() => {
+          const mod = pkg.modules.find((mod) => mod.name === modName);
+          if (!mod) {
+            return [<ModuleList pkg={pkg} />, `Module ${modName} not found :O`];
+          }
+
+          const cls = mod.classes.find(
+            (cls) => withoutPrefix(mod.name, cls.name) === symName
+          );
+          const func = mod.functions.find(
+            (func) => withoutPrefix(mod.name, func.name) === symName
+          );
+          const variable = mod.variables.find(
+            (variable) => withoutPrefix(mod.name, variable.name) === symName
+          );
+          const symbol = cls || func || variable;
+
+          if (!symbol) {
+            return [<ModuleList pkg={pkg} />, `Symbol ${symName} not found :O`];
+          }
+
+          const Sidebar = cls ? (
+            <>
+              <ClassContents pkg={pkg} mod={mod} cls={cls} currentSymbol="" />
+              <ModuleContents pkg={pkg} mod={mod} currentSymbol="" />
+            </>
+          ) : (
+            <ModuleContents pkg={pkg} mod={mod} currentSymbol={symbol.name} />
+          );
+
+          if (cls) {
+            return [Sidebar, <Class cls={cls} />];
+          } else if (func) {
+            return [
+              Sidebar,
+              <>
+                {mod.functions
+                  .filter((f) => f.name === symbol.name)
+                  .map((f) => (
+                    <Function func={f} />
+                  ))}
+              </>,
+            ];
+          } else {
+            // variable
+            return [
+              Sidebar,
+              <>
+                {mod.variables
+                  .filter((v) => v.name === symbol.name)
+                  .map((v) => (
+                    <Variable variable={v} />
+                  ))}
+              </>,
+            ];
+          }
+        })();
+
+        return (
+          <Layout pkg={pkg} sidebar={Sidebar}>
+            {Content}
+          </Layout>
+        );
+      }}
+    />
   );
 }

--- a/www/pages/[pkg]/[mod]/[symbol].tsx
+++ b/www/pages/[pkg]/[mod]/[symbol].tsx
@@ -23,7 +23,7 @@ export default function ModulePage() {
         const [Sidebar, Content] = (() => {
           const mod = pkg.modules.find((mod) => mod.name === modName);
           if (!mod) {
-            return [<ModuleList pkg={pkg} />, `Module ${modName} not found :O`];
+            return [<ModuleList pkg={pkg} />, `Module ${modName} not found 🤪`];
           }
 
           const cls = mod.classes.find(
@@ -38,7 +38,7 @@ export default function ModulePage() {
           const symbol = cls || func || variable;
 
           if (!symbol) {
-            return [<ModuleList pkg={pkg} />, `Symbol ${symName} not found :O`];
+            return [<ModuleList pkg={pkg} />, `Symbol ${symName} not found 🤪`];
           }
 
           const Sidebar = cls ? (

--- a/www/pages/index.tsx
+++ b/www/pages/index.tsx
@@ -4,11 +4,17 @@ import Head from "next/head";
 import Link from "next/link";
 import React from "react";
 
-import { Pkg, getPackageIndex } from "@/lib/docs";
+import { getPackage, listPackages } from "@/lib/docs";
 import * as url from "@/lib/url";
 
-export const getStaticProps: GetStaticProps<Props> = () => {
-  const packages = getPackageIndex();
+export const getStaticProps: GetStaticProps<Props> = async () => {
+  const packageNames = await listPackages();
+  const packages = await Promise.all(
+    packageNames.map(async (name) => ({
+      name,
+      version: (await getPackage(name)).version,
+    }))
+  );
   return {
     props: {
       packages,
@@ -19,7 +25,7 @@ export const getStaticProps: GetStaticProps<Props> = () => {
 const theme = createTheme();
 
 interface Props {
-  packages: Pkg[];
+  packages: { name: string; version: string }[];
 }
 
 export default function Home({ packages }: Props) {

--- a/www/pages/index.tsx
+++ b/www/pages/index.tsx
@@ -4,7 +4,7 @@ import Head from "next/head";
 import Link from "next/link";
 import React from "react";
 
-import { getPackage, listPackages } from "@/lib/docs";
+import { Pkg, getPackage, listPackages } from "@/lib/docs";
 import * as url from "@/lib/url";
 
 export const getStaticProps: GetStaticProps<Props> = async () => {
@@ -41,7 +41,7 @@ export default function Home({ packages }: Props) {
           <ul>
             {packages.map((pkg) => (
               <li key={`${pkg.name}-${pkg.version}`}>
-                <Link href={url.pkg(pkg)}>
+                <Link href={url.pkg(pkg as Pkg)}>
                   <a>{pkg.name}</a>
                 </Link>{" "}
                 ({pkg.version})


### PR DESCRIPTION
Generating static pages for each symbol is a no-go; way too many, way
too big content. Let's "just" request the JSON from the client, and
render on the client.

* Fetching (including caching) with https://swr.vercel.app/, as
  recommended by Next.js
* Updated `README.md` (and created `.gitkeep`) to store devenv index in
  `www/public`, so that it gets served at the same URL as in prod