### PR TITLE
feat: gather explicitly exported symbols

### DIFF
--- a/py_wtf/indexer.py
+++ b/py_wtf/indexer.py
@@ -1,16 +1,19 @@
 import itertools
 from pathlib import Path
 from textwrap import dedent
-from typing import Iterable, Protocol, Tuple, TypeVar
+from typing import Iterable, Protocol, TypeVar
 
 import libcst as cst
+from libcst.codemod import CodemodContext
+from libcst.codemod.visitors import GatherExportsVisitor
+from libcst.helpers.expression import get_full_name_for_node
 
 from .types import (
     Class,
     Documentation,
+    FQName,
     Function,
     Module,
-    Package,
     Parameter,
     Type,
     Variable,
@@ -35,6 +38,7 @@ def index_file(base_dir: Path, path: Path) -> Module:
         classes=indexer.classes,
         functions=indexer.functions,
         variables=indexer.variables,
+        exports=indexer.exports,
     )
 
 
@@ -96,15 +100,53 @@ class Indexer(cst.CSTVisitor):
     def __init__(self, scope: str | None = None) -> None:
         super().__init__()
         self._scope_name: str | None = scope
+        self._symbol_table: dict[str, FQName] = {}
         self.classes: list[Class] = []
         self.functions: list[Function] = []
         self.variables: list[Variable] = []
         self.documentation: list[Documentation] = []
+        self.exports: list[FQName] = []
 
-    def scoped_name(self, name: str) -> str:
+    def leave_Module(self, original_node: cst.Module) -> None:
+        vis = GatherExportsVisitor(CodemodContext())
+        original_node.visit(vis)
+        # Maybe have an exports section?
+        self.exports.extend(
+            self._symbol_table.get(name, FQName(name))
+            for name in vis.explicit_exported_objects
+        )
+
+    def scoped_name(self, name: str) -> FQName:
         if self._scope_name:
-            return f"{self._scope_name}.{name}"
-        return name
+            return FQName(f"{self._scope_name}.{name}")
+        return FQName(name)
+
+    def visit_Import(self, node: cst.Import) -> bool:
+        for name in node.names:
+            if (asname := name.evaluated_alias) is not None:
+                self._symbol_table[asname] = FQName(name.evaluated_name)
+        return False
+
+    def visit_ImportFrom(self, node: cst.ImportFrom) -> bool:
+        if isinstance(node.names, cst.ImportStar):
+            return False
+
+        from_mod = ""
+        if node.relative:
+            if self._scope_name is None:
+                raise ValueError("Tried relative import when scope name is empty")
+            from_mod = self._scope_name.rsplit(".", len(node.relative) - 1)[0] + "."
+        if node.module:
+            from_mod += get_full_name_for_node(node.module) or ""
+        for name in node.names:
+            source = f"{from_mod}.{name.evaluated_name}"
+            target = (
+                asname
+                if (asname := name.evaluated_alias) is not None
+                else name.evaluated_name
+            )
+            self._symbol_table[target] = FQName(source)
+        return False
 
     def visit_IndentedBlock(self, node: cst.IndentedBlock) -> bool:
         if (hdr := extract_documentation(node.header)) is not None:
@@ -186,6 +228,10 @@ class Indexer(cst.CSTVisitor):
         my_name = name(target)
         if my_name is None:
             # it's not a Name or Attribute
+            return False
+
+        if my_name == "__all__":
+            # Handled by GatherExportsVisitor
             return False
 
         self.variables.append(

--- a/py_wtf/types.py
+++ b/py_wtf/types.py
@@ -8,6 +8,7 @@ from dataclasses_json import dataclass_json  # type: ignore
 
 Type = NewType("Type", str)
 Documentation = NewType("Documentation", str)
+FQName = NewType("FQName", str)
 
 
 @dataclass_json  # type: ignore
@@ -56,6 +57,7 @@ class Module:
     functions: Iterable[Function]
     variables: Iterable[Variable]
     classes: Iterable[Class]
+    exports: Iterable[FQName]
 
 
 @dataclass_json  # type: ignore

--- a/test_fixtures/project-alpha/alpha/__init__.py
+++ b/test_fixtures/project-alpha/alpha/__init__.py
@@ -7,4 +7,6 @@ Please don't use it in production.
 from .core import *
 from foo import bar
 
-__all__ = ["bar", "core_main"]
+from .core import Helper
+
+__all__ = ["bar", "core_main", "Helper"]

--- a/www/lib/docs.ts
+++ b/www/lib/docs.ts
@@ -29,6 +29,7 @@ export type Module = {
   functions: Array<Func>;
   variables: Array<Variable>;
   classes: Array<Class>;
+  exports: Array<string>;
 };
 
 export type Func = {


### PR DESCRIPTION
Explicitly exported symbols are collected into the `Module`'s `exports` field. This contains a list of fully qualified names for now, but we might want to switch to a smarter representation (maybe something like what's described in #8).

See https://docs.python.org/3/tutorial/modules.html#importing-from-a-package for how `__all__` works.

Closes #7
