### PR TITLE
Use a common dummy theme across the app

### DIFF
--- a/www/components/Docs/SymbolLinkTable.tsx
+++ b/www/components/Docs/SymbolLinkTable.tsx
@@ -42,7 +42,7 @@ export default function SymbolLinkTable<T extends Sym>({
     return <></>;
   }
   return (
-    <Box>
+    <Box color="grey.300">
       <Text variant="h3">{title}</Text>
       <Table>
         <Table.Tbody>

--- a/www/components/Layout.tsx
+++ b/www/components/Layout.tsx
@@ -1,15 +1,11 @@
 import { Box } from "@welcome-ui/box";
-import { WuiProvider, createTheme } from "@welcome-ui/core";
 import { Flex } from "@welcome-ui/flex";
 import { Stack } from "@welcome-ui/stack";
-import { darkTheme } from "@welcome-ui/themes.dark";
 import React, { ReactNode } from "react";
 
 import { Pkg } from "@/lib/docs";
 
 import Sidebar from "./Sidebar/Sidebar";
-
-const theme = createTheme(darkTheme);
 
 interface Props {
   pkg: Pkg;
@@ -19,15 +15,13 @@ interface Props {
 
 export default function Layout({ pkg, sidebar, children }: Props) {
   return (
-    <WuiProvider theme={theme}>
-      <Flex backgroundColor="light.700" color="dark.700" direction="column">
-        <Stack direction="row" minHeight="100vh">
-          <Sidebar pkg={pkg}>{sidebar}</Sidebar>
-          <Box marginLeft="md" maxWidth="80em">
-            {children}
-          </Box>
-        </Stack>
-      </Flex>
-    </WuiProvider>
+    <Flex backgroundColor="slate.500" color="grey.300" direction="column">
+      <Stack direction="row" minHeight="100vh">
+        <Sidebar pkg={pkg}>{sidebar}</Sidebar>
+        <Box backgroundColor="slate.500" marginLeft="md" maxWidth="80em">
+          {children}
+        </Box>
+      </Stack>
+    </Flex>
   );
 }

--- a/www/components/Sidebar/Sidebar.tsx
+++ b/www/components/Sidebar/Sidebar.tsx
@@ -14,21 +14,24 @@ export interface Props {
 }
 
 const Container = styled(Box)`
-  overflow: auto;
-  background-color: #151515;
-  padding-left: ${(props) => props.theme.space.xxl};
-  border-right: ${(props) => props.theme.colors.light[200]} 5px solid;
   height: 100%;
+  min-width: 15em;
+  padding-left: ${(props) => props.theme.space.xxl};
+
+  background-color: ${(props) => props.theme.colors.slate[700]};
+  border-right: ${(props) => props.theme.colors.slate[200]} 10px solid;
+
+  overflow: auto;
 `;
 
 const StyledLink = styled(Link)`
-  color: ${(props) => props.theme.colors.dark[800]};
+  color: ${(props) => props.theme.colors.grey[300]};
   text-decoration: none;
 `;
 
 export default function Sidebar({ pkg, children }: Props) {
   return (
-    <Container>
+    <Container color="grey.100">
       <StyledLink to={url.pkg(pkg)}>
         <Text variant="h3" paddingRight="xl" cursor="pointer">
           Package {pkg.name}

--- a/www/components/core/theme/theme.ts
+++ b/www/components/core/theme/theme.ts
@@ -1,0 +1,47 @@
+import { createTheme } from "@welcome-ui/core";
+
+const colors = {
+  primary: {
+    500: "#FF0000",
+  },
+  secondary: {
+    500: "#00FF00",
+  },
+  slate: {
+    200: "#65686b",
+    500: "#292c33",
+    700: "#191c20",
+  },
+  grey: {
+    100: "#ffffff",
+    300: "#dedede",
+  },
+};
+
+export const theme = createTheme({
+  colors: colors,
+  // spacing: {
+  //   "3xl": 50,
+  //   "4xl": 70,
+  // },
+  // example if you need to remove border radius
+  // radii: {
+  //   sm: 0,
+  //   md: 0,
+  //   lg: 0,
+  // },
+  // space: {
+  //   lg: 24,
+  // },
+  // breakpoints: {
+  //   xl: 1024,
+  // },
+  links: {
+    default: {
+      color: "cornflowerblue",
+    },
+    sidebarLink: {
+      color: colors.grey[300],
+    },
+  },
+});

--- a/www/components/highlight.tsx
+++ b/www/components/highlight.tsx
@@ -3,7 +3,7 @@ import React from "react";
 import styled from "styled-components";
 
 export const Container = (props: TextProps) => (
-  <Text as="code" backgroundColor="light.800" padding="md" {...props} />
+  <Text as="code" backgroundColor="slate.700" padding="md" {...props} />
 );
 
 export const Keyword = styled.span`

--- a/www/pages/_spa.tsx
+++ b/www/pages/_spa.tsx
@@ -1,21 +1,25 @@
+import { WuiProvider } from "@welcome-ui/core";
 import React from "react";
 import { Route, BrowserRouter as Router, Routes } from "react-router-dom";
 
 import ModulePage from "@/components/SPA/ModulePage";
 import PackagePage from "@/components/SPA/PackagePage";
 import SymbolPage from "@/components/SPA/SymbolPage";
+import { theme } from "@/components/core/theme/theme";
 
 import * as spa from "@/lib/spa";
 
 export default function SPAIndex() {
   spa.receive();
   return (
-    <Router>
-      <Routes>
-        <Route path="/:pkg" element={<PackagePage />} />
-        <Route path="/:pkg/:mod" element={<ModulePage />} />
-        <Route path="/:pkg/:mod/:sym" element={<SymbolPage />} />
-      </Routes>
-    </Router>
+    <WuiProvider theme={theme}>
+      <Router>
+        <Routes>
+          <Route path="/:pkg" element={<PackagePage />} />
+          <Route path="/:pkg/:mod" element={<ModulePage />} />
+          <Route path="/:pkg/:mod/:sym" element={<SymbolPage />} />
+        </Routes>
+      </Router>
+    </WuiProvider>
   );
 }

--- a/www/pages/index.tsx
+++ b/www/pages/index.tsx
@@ -3,6 +3,9 @@ import { GetStaticProps } from "next";
 import Head from "next/head";
 import Link from "next/link";
 import React from "react";
+import styled from "styled-components";
+
+import { theme } from "@/components/core/theme/theme";
 
 import { Pkg, getPackage, listPackages } from "@/lib/docs";
 import * as url from "@/lib/url";
@@ -22,7 +25,40 @@ export const getStaticProps: GetStaticProps<Props> = async () => {
   };
 };
 
-const theme = createTheme();
+const PageContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+
+  min-height: 100vh;
+  padding: 0 0.5rem;
+
+  background-color: ${(props) => props.theme.colors.slate[500]};
+  color: ${(props) => props.theme.colors.grey[300]};
+`;
+
+const StyledPackageLink = styled.a`
+  color: cornflowerblue;
+`;
+
+const Content = styled.main`
+  padding: 5rem 0;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+`;
+
+const Footer = styled.footer`
+  width: 100%;
+  height: 100px;
+  border-top: 1px solid #eaeaea;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
 
 interface Props {
   packages: { name: string; version: string }[];
@@ -31,56 +67,27 @@ interface Props {
 export default function Home({ packages }: Props) {
   return (
     <WuiProvider theme={theme}>
-      <div className="container">
+      <PageContainer>
         <Head>
           <title>py.wtf</title>
           {/*<link rel="icon" href="/favicon.ico" /> */}
         </Head>
 
-        <main>
+        <Content>
           <ul>
             {packages.map((pkg) => (
               <li key={`${pkg.name}-${pkg.version}`}>
-                <Link href={url.pkg(pkg as Pkg)}>
-                  <a>{pkg.name}</a>
-                </Link>{" "}
+                <StyledPackageLink href={url.pkg(pkg as Pkg)}>
+                  {pkg.name}
+                </StyledPackageLink>{" "}
                 ({pkg.version})
               </li>
             ))}
           </ul>
-        </main>
+        </Content>
 
-        <footer>Footer.</footer>
-
-        <style jsx>{`
-          .container {
-            min-height: 100vh;
-            padding: 0 0.5rem;
-            display: flex;
-            flex-direction: column;
-            justify-content: center;
-            align-items: center;
-          }
-
-          main {
-            padding: 5rem 0;
-            flex: 1;
-            display: flex;
-            flex-direction: column;
-            justify-content: center;
-            align-items: center;
-          }
-
-          footer {
-            width: 100%;
-            height: 100px;
-            border-top: 1px solid #eaeaea;
-            display: flex;
-            justify-content: center;
-            align-items: center;
-          }
-        `}</style>
-      </div>
+        <Footer>Footer.</Footer>
+      </PageContainer>
     </WuiProvider>
   );
 }

--- a/www/pages/index.tsx
+++ b/www/pages/index.tsx
@@ -39,7 +39,7 @@ const PageContainer = styled.div`
 `;
 
 const StyledPackageLink = styled.a`
-  color: cornflowerblue;
+  color: ${(props) => props.theme.links.default.color};
 `;
 
 const Content = styled.main`


### PR DESCRIPTION
The changes:
- Added a very basic common theme under `core/theme`
- Removed all unnecessary theme providers
- Made the root nodes use the common theme
- Made the text at least readable

This is by no means a final theme, just something to get started with as we're extracting components and figure out what colors and styles we actually need.