### PR TITLE
feat: add a project repository to the indexer

### DIFF
--- a/py_wtf/cli/__init__.py
+++ b/py_wtf/cli/__init__.py
@@ -43,9 +43,6 @@ def index(project_name: str, directory: str, pretty: bool, force: bool) -> None:
 
     if pretty:
         rich.print(proj)
-    else:
-        out = out_dir / f"{project_name}.json"
-        out.write_text(proj.to_json())  # type: ignore
 
 
 @py_wtf.command(name="index-file")

--- a/py_wtf/cli/__init__.py
+++ b/py_wtf/cli/__init__.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import json
 import os
+import shutil
 from pathlib import Path
 
 import click
@@ -12,7 +13,8 @@ import rich
 
 from py_wtf.__about__ import __version__
 from py_wtf.indexer import index_dir, index_file, index_project
-from py_wtf.types import Documentation, Project, ProjectMetadata
+from py_wtf.repository import ProjectRepository
+from py_wtf.types import Documentation, Project, ProjectMetadata, ProjectName
 
 
 @click.group(
@@ -29,11 +31,15 @@ def py_wtf(ctx: click.Context) -> None:
 @click.argument("directory")
 @click.option("--project-name", required=True)
 @click.option("--pretty", is_flag=True)
-def index(project_name: str, directory: str, pretty: bool) -> None:
+@click.option("--force", is_flag=True, help="Blow away index repository and reindex")
+def index(project_name: str, directory: str, pretty: bool, force: bool) -> None:
     out_dir = Path(directory)
+    if force:
+        shutil.rmtree(out_dir, ignore_errors=True)
     out_dir.mkdir(parents=True, exist_ok=True)
+    repo = ProjectRepository(out_dir)
 
-    proj = next(iter(index_project(project_name)))
+    proj = repo.get(ProjectName(project_name), index_project)
 
     if pretty:
         rich.print(proj)
@@ -81,7 +87,7 @@ def generate_test_index() -> None:
         )
         mods = index_dir(proj_dir)
         proj = Project(
-            proj_dir.name,
+            ProjectName(proj_dir.name),
             metadata=proj_info,
             modules=list(mods),
             documentation=[Documentation(proj_info.summary or "")],

--- a/py_wtf/indexer/pypi.py
+++ b/py_wtf/indexer/pypi.py
@@ -9,11 +9,11 @@ from zipfile import is_zipfile, ZipFile
 import trailrunner
 from packaging.requirements import Requirement
 
-from py_wtf.types import Documentation, Module, Project, ProjectMetadata
+from py_wtf.types import Documentation, Module, Project, ProjectMetadata, ProjectName
 from .file import index_dir
 
 
-def index_project(project_name: str) -> Iterable[Project]:
+def index_project(project_name: ProjectName) -> Iterable[Project]:
     with TemporaryDirectory() as tmpdir:
         src_dir, info = download(project_name, Path(tmpdir))
         modules = list(index_dir(src_dir))

--- a/py_wtf/repository.py
+++ b/py_wtf/repository.py
@@ -1,0 +1,57 @@
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Callable, Iterable
+
+from py_wtf.types import Project, ProjectName
+
+
+@dataclass(slots=True)
+class ProjectRepository:
+    directory: Path
+
+    _cache: dict[ProjectName, Project] = field(init=False)
+
+    def __post_init__(self) -> None:
+        self._cache = {}
+
+    def __getitem__(self, key: ProjectName) -> Project:
+        if key not in self._cache:
+            try:
+                self._load_from_disk(key)
+            except OSError:
+                raise KeyError(key)
+
+        return self._cache[key]
+
+    def _index_file(self, key: ProjectName) -> Path:
+        return self.directory / f"{key}.json"
+
+    def _load_from_disk(self, key: ProjectName) -> None:
+        index_file = self._index_file(key)
+        index_contents = index_file.read_bytes()
+        proj: Project = Project.from_json(index_contents)  # type: ignore
+        self._cache[key] = proj
+
+    def _save(self, project: Project) -> None:
+        name = ProjectName(project.name)
+        if name in self._cache:
+            return
+
+        self._cache[name] = project
+        index_file = self._index_file(name)
+        index_file.write_text(project.to_json())  # type: ignore
+
+    def get(
+        self,
+        key: ProjectName,
+        factory: Callable[[ProjectName], Iterable[Project]],
+    ) -> Project:
+        try:
+            return self[key]
+        except KeyError:
+            pass  # continued below
+        projects = factory(key)
+        for project in projects:
+            self._save(project)
+
+        return self[key]

--- a/py_wtf/types.py
+++ b/py_wtf/types.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Iterable, NewType, Sequence
+from typing import Iterable, NewType
 
 from dataclasses_json import dataclass_json
 
@@ -9,6 +9,7 @@ from dataclasses_json import dataclass_json
 Type = NewType("Type", str)
 Documentation = NewType("Documentation", str)
 FQName = NewType("FQName", str)
+ProjectName = NewType("ProjectName", str)
 
 
 @dataclass_json
@@ -63,7 +64,7 @@ class Module:
 @dataclass_json
 @dataclass(frozen=True)
 class Project:
-    name: str
+    name: ProjectName
     metadata: ProjectMetadata
     documentation: Iterable[Documentation]
     modules: Iterable[Module]
@@ -72,9 +73,9 @@ class Project:
 @dataclass
 class ProjectMetadata:
     version: str
-    classifiers: Sequence[str] | None
+    classifiers: Iterable[str] | None
     home_page: str | None
     license: str | None
     documentation_url: str | None
-    dependencies: Sequence[str]
+    dependencies: Iterable[str]
     summary: str | None

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -1,0 +1,79 @@
+from dataclasses import replace
+from pathlib import Path
+from typing import Iterable
+
+import pytest
+from py_wtf.repository import ProjectRepository
+from py_wtf.types import Project, ProjectMetadata, ProjectName
+
+
+@pytest.fixture
+def project() -> Project:
+    return Project(
+        name=ProjectName("testproject"),
+        metadata=ProjectMetadata(
+            version="1.1.1.1.1",
+            classifiers=None,
+            home_page=None,
+            license=None,
+            documentation_url=None,
+            dependencies=[],
+            summary=None,
+        ),
+        modules=[],
+        documentation=[],
+    )
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> ProjectRepository:
+    return ProjectRepository(tmp_path)
+
+
+def test_empty_raises(repo: ProjectRepository) -> None:
+    with pytest.raises(KeyError):
+        repo[ProjectName("foo")]
+
+
+def test_get_calls_factory_once(repo: ProjectRepository, project: Project) -> None:
+    called = False
+
+    def factory(key: ProjectName) -> Iterable[Project]:
+        nonlocal called
+        called = True
+        yield project
+
+    ret = repo.get(project.name, factory)
+    assert called
+    assert ret == project
+
+    called = False
+
+    ret = repo.get(project.name, factory)
+    assert not called
+    assert ret == project
+
+
+def test_index_works(repo: ProjectRepository, project: Project) -> None:
+    repo._save(project)
+    assert repo[project.name] == project
+
+
+def test_save_writes_to_disk(repo: ProjectRepository, project: Project) -> None:
+    repo._save(project)
+    assert (repo.directory / f"{project.name}.json").exists()
+
+
+def test_getitem_loads_from_disk(repo: ProjectRepository, project: Project) -> None:
+    index_file = repo.directory / f"{project.name}.json"
+    index_file.write_text(project.to_json())  # type: ignore
+    assert repo[project.name] == project
+
+
+def test_double_save(repo: ProjectRepository, project: Project) -> None:
+    other_project = replace(project, documentation=["foo"])
+    assert project != other_project
+    repo._save(project)
+    assert repo[project.name] == project
+    repo._save(other_project)
+    assert repo[other_project.name] == project


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #70
* #67
* #65
* #64
* #63
* #62
* __->__ #58

This acts as a cache layer between the indexer and the filesystem. In the future, the
indexer will ask for a project's dependencies from here for cross-referencing purposes.