### PR TITLE
Fixed the function signature display

### DIFF
--- a/www/components/Docs/Function.tsx
+++ b/www/components/Docs/Function.tsx
@@ -36,7 +36,7 @@ export default function Function({ func }: { func: Func }) {
   const def = func.asynchronous ? "async def" : "def";
   const ret = func.returns && (
     <>
-      {" -> "}
+      {"-> "}
       <hl.Ty>{func.returns}</hl.Ty>
     </>
   );

--- a/www/components/highlight.tsx
+++ b/www/components/highlight.tsx
@@ -22,7 +22,11 @@ export function VarWithType({ name, type, comma = false }: VarWithTypeProps) {
   return (
     <>
       {name}
-      {type != null && <Ty>{type}</Ty>}
+      {type != null && (
+        <>
+          : <Ty>{type}</Ty>
+        </>
+      )}
       {comma && ","}
     </>
   );


### PR DESCRIPTION
Yesterday's styling refactor broke the function signature display, removing the `:` before the type of the parameters and adding an extra space before the return arrow. This PR fixes it, making the display great again:

![image](https://user-images.githubusercontent.com/619826/184527438-9080527d-afc7-4c4f-94e0-241361d15a42.png)
