### PR TITLE
fix: dont include deps with markers

### DIFF
--- a/py_wtf/indexer/pypi.py
+++ b/py_wtf/indexer/pypi.py
@@ -61,7 +61,14 @@ def pick_project_dir(directory: Path) -> Path:
 def parse_deps(maybe_deps: None | Sequence[str]) -> Sequence[str]:
     if not maybe_deps:
         return ()
-    return tuple(req.name for dep in maybe_deps if not (req := Requirement(dep)).extras)
+
+    return tuple(
+        req.name
+        for dep in maybe_deps
+        if (req := Requirement(dep))
+        if not req.extras
+        if not req.marker
+    )
 
 
 def download(project_name: str, directory: Path) -> Tuple[Path, ProjectMetadata]:

--- a/tests/indexer/test_pypi.py
+++ b/tests/indexer/test_pypi.py
@@ -97,3 +97,8 @@ def test_download(tmp_path: Path) -> None:
     assert metadata.license == "BSD"
     assert path.is_relative_to(tmp_path)
     assert (path / "foo_mod.py").exists()
+
+
+def test_no_extras_in_deps(tmp_path: Path) -> None:
+    _, metadata = download("foo", tmp_path)
+    assert "aiohttp" not in metadata.dependencies


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #70
* #67
* #65
* #64
* #63
* __->__ #62
* #58

While indexing projects, any dependency that has a marker like `extra == 'foo'` should be skipped. These markers can easily cause circular dependencies amongst projects.