### PR TITLE
chore: replace dataclasses_json with cattrs

### DIFF
--- a/py_wtf/cli/__init__.py
+++ b/py_wtf/cli/__init__.py
@@ -15,7 +15,7 @@ import rich
 
 from py_wtf.__about__ import __version__
 from py_wtf.indexer import index_dir, index_file, index_project
-from py_wtf.repository import ProjectRepository
+from py_wtf.repository import converter, ProjectRepository
 from py_wtf.types import Documentation, Project, ProjectMetadata, ProjectName
 
 
@@ -92,4 +92,4 @@ def generate_test_index() -> None:
             modules=list(mods),
             documentation=[Documentation(proj_info.summary or "")],
         )
-        (out_dir / f"{proj.name}.json").write_text(proj.to_json())  # type: ignore
+        (out_dir / f"{proj.name}.json").write_text(converter.dumps(proj))

--- a/py_wtf/indexer/file.py
+++ b/py_wtf/indexer/file.py
@@ -196,7 +196,7 @@ class Indexer(cst.CSTVisitor):
 
     def visit_ClassDef(self, node: cst.ClassDef) -> bool:
         my_name = self.scoped_name(ensure(name(node.name)))
-        bases = tuple(filter(None, (name(arg.value) for arg in node.bases)))
+        bases = list(filter(None, (name(arg.value) for arg in node.bases)))
         comments = filter(
             None, (extract_documentation(line) for line in node.leading_lines)
         )
@@ -208,9 +208,9 @@ class Indexer(cst.CSTVisitor):
                 bases,
                 methods=indexer.functions,
                 class_variables=indexer.variables,
-                instance_variables=(),  # TODO
+                instance_variables=[],  # TODO
                 inner_classes=indexer.classes,
-                documentation=(*indexer.documentation, *comments),
+                documentation=[*indexer.documentation, *comments],
             )
         )
         return False
@@ -232,9 +232,9 @@ class Indexer(cst.CSTVisitor):
             Function(
                 my_name,
                 asynchronous,
-                params=tuple(params),
+                params=list(params),
                 returns=returns,
-                documentation=(*indexer.documentation, *comments),
+                documentation=[*indexer.documentation, *comments],
             )
         )
         return False
@@ -259,7 +259,7 @@ class Indexer(cst.CSTVisitor):
             Variable(
                 name=self.scoped_name(my_name),
                 type=None,
-                documentation=(),  # TODO
+                documentation=[],  # TODO
             )
         )
         return False
@@ -277,7 +277,7 @@ class Indexer(cst.CSTVisitor):
             Variable(
                 my_name,
                 type,
-                documentation=(),  # TODO
+                documentation=[],  # TODO
             )
         )
         return False

--- a/py_wtf/indexer/pypi.py
+++ b/py_wtf/indexer/pypi.py
@@ -36,7 +36,7 @@ def index_project(
         project_name,
         metadata=info,
         modules=modules,
-        documentation=(),
+        documentation=[],
     )
     yield proj
 
@@ -72,11 +72,11 @@ def pick_project_dir(directory: Path) -> Path:
     return project_directory
 
 
-def parse_deps(maybe_deps: None | Sequence[str]) -> Sequence[str]:
+def parse_deps(maybe_deps: None | Sequence[str]) -> list[str]:
     if not maybe_deps:
-        return ()
+        return []
 
-    return tuple(
+    return list(
         req.name
         for dep in maybe_deps
         if (req := Requirement(dep))

--- a/py_wtf/repository.py
+++ b/py_wtf/repository.py
@@ -1,8 +1,12 @@
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Callable, Iterable
+from typing import Callable, Iterable, NewType
+
+from cattrs.preconf.json import make_converter
 
 from py_wtf.types import Project, ProjectName
+
+converter = make_converter()
 
 
 @dataclass(slots=True)
@@ -29,7 +33,7 @@ class ProjectRepository:
     def _load_from_disk(self, key: ProjectName) -> None:
         index_file = self._index_file(key)
         index_contents = index_file.read_bytes()
-        proj: Project = Project.from_json(index_contents)  # type: ignore
+        proj = converter.loads(index_contents, Project)
         self._cache[key] = proj
 
     def _save(self, project: Project) -> None:
@@ -39,7 +43,7 @@ class ProjectRepository:
 
         self._cache[name] = project
         index_file = self._index_file(name)
-        index_file.write_text(project.to_json())  # type: ignore
+        index_file.write_text(converter.dumps(project))
 
     def get(
         self,

--- a/py_wtf/types.py
+++ b/py_wtf/types.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Iterable, NewType
+from typing import NewType, TYPE_CHECKING
 
-from dataclasses_json import dataclass_json
 
+if not TYPE_CHECKING:
+    NewType = lambda _, ty: ty
 
 Type = NewType("Type", str)
 Documentation = NewType("Documentation", str)
@@ -12,15 +13,13 @@ FQName = NewType("FQName", str)
 ProjectName = NewType("ProjectName", str)
 
 
-@dataclass_json
 @dataclass(frozen=True)
 class Variable:
     name: str
     type: Type | None
-    documentation: Iterable[Documentation]
+    documentation: list[Documentation]
 
 
-@dataclass_json
 @dataclass(frozen=True)
 class Parameter:
     name: str
@@ -28,54 +27,50 @@ class Parameter:
     default: str | None
 
 
-@dataclass_json
 @dataclass(frozen=True)
 class Function:
     name: str
     asynchronous: bool
-    params: Iterable[Parameter]
+    params: list[Parameter]
     returns: Type | None
-    documentation: Iterable[Documentation]
+    documentation: list[Documentation]
 
 
-@dataclass_json
 @dataclass(frozen=True)
 class Class:
     name: str
-    bases: Iterable[str]
-    methods: Iterable[Function]
-    class_variables: Iterable[Variable]
-    instance_variables: Iterable[Variable]
-    inner_classes: Iterable[Class]
-    documentation: Iterable[Documentation]
+    bases: list[str]
+    methods: list[Function]
+    class_variables: list[Variable]
+    instance_variables: list[Variable]
+    inner_classes: list[Class]
+    documentation: list[Documentation]
 
 
-@dataclass_json
 @dataclass(frozen=True)
 class Module:
     name: str
-    documentation: Iterable[Documentation]
-    functions: Iterable[Function]
-    variables: Iterable[Variable]
-    classes: Iterable[Class]
-    exports: Iterable[FQName]
+    documentation: list[Documentation]
+    functions: list[Function]
+    variables: list[Variable]
+    classes: list[Class]
+    exports: list[FQName]
 
 
-@dataclass_json
 @dataclass(frozen=True)
 class Project:
     name: ProjectName
     metadata: ProjectMetadata
-    documentation: Iterable[Documentation]
-    modules: Iterable[Module]
+    documentation: list[Documentation]
+    modules: list[Module]
 
 
 @dataclass
 class ProjectMetadata:
     version: str
-    classifiers: Iterable[str] | None
+    classifiers: list[str] | None
     home_page: str | None
     license: str | None
     documentation_url: str | None
-    dependencies: Iterable[str]
+    dependencies: list[str]
     summary: str | None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,8 +19,8 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
 ]
 dependencies = [
+  "cattrs==22.1.0",
   "click>=8.1.3",
-  "dataclasses-json>=0.5.7",
   "rich>=12.5.1",
   "libcst>=0.4.7",
   "trailrunner>=1.2.1",

--- a/tests/indexer/test_file.py
+++ b/tests/indexer/test_file.py
@@ -6,7 +6,7 @@ from py_wtf.indexer import file as mod_under_test
 from py_wtf.indexer.file import index_dir, index_file
 from py_wtf.types import Module
 
-empty_module = Module("testmod", (), (), (), (), ())
+empty_module = Module("testmod", [], [], [], [], [])
 
 
 def mock_index_file(base_dir: Path, path: Path) -> Module:

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from typing import Iterable
 
 import pytest
-from py_wtf.repository import ProjectRepository
+from py_wtf.repository import converter, ProjectRepository
 from py_wtf.types import Project, ProjectMetadata, ProjectName
 
 
@@ -66,7 +66,7 @@ def test_save_writes_to_disk(repo: ProjectRepository, project: Project) -> None:
 
 def test_getitem_loads_from_disk(repo: ProjectRepository, project: Project) -> None:
     index_file = repo.directory / f"{project.name}.json"
-    index_file.write_text(project.to_json())  # type: ignore
+    index_file.write_text(converter.dumps(project))
     assert repo[project.name] == project
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #70
* #67
* #65
* __->__ #64
* #63
* #62
* #58

dataclasses_json was silently failing to support NewTypes and Iterables. cattrs also doesn't support them yet, but is at least loud about them.