### PR TITLE
BREAKING CHANGE: link module exports to the project they come from

### DIFF
--- a/py_wtf/indexer/file.py
+++ b/py_wtf/indexer/file.py
@@ -17,12 +17,14 @@ from py_wtf.types import (
     Function,
     Module,
     Parameter,
+    ProjectName,
+    SymbolTable,
     Type,
     Variable,
 )
 
 
-def index_dir(dir: Path) -> Iterable[Module]:
+def index_dir(dir: Path, symbol_table: SymbolTable | None = None) -> Iterable[Module]:
     # TODO: do something with .pyi files
     # If there's a .pyi file with no corresponding .py -> just index .pyi
     # If both of them exist, do a best effort merge? 🤷
@@ -31,17 +33,28 @@ def index_dir(dir: Path) -> Iterable[Module]:
     # Skip looking for root markers, we definitely want to index this directory.
     trailrunner.core.ROOT_MARKERS = []
     for (_, mod) in trailrunner.run_iter(
-        paths=trailrunner.walk(dir), func=partial(index_file, dir)
+        paths=trailrunner.walk(dir),
+        func=partial(
+            index_file,
+            dir,
+            symbol_table=symbol_table,
+        ),
     ):
         yield mod
 
 
-def index_file(base_dir: Path, path: Path) -> Module:
+def index_file(
+    base_dir: Path,
+    path: Path,
+    symbol_table: SymbolTable | None = None,
+) -> Module:
+    if not symbol_table:
+        symbol_table = {}
     name_parts = path.relative_to(base_dir).with_suffix("").parts
     if name_parts[-1] == "__init__":
         name_parts = name_parts[:-1]
     name = ".".join(name_parts)
-    indexer = Indexer(name)
+    indexer = Indexer(name, symbol_table)
     try:
         mod = cst.MetadataWrapper(
             cst.parse_module(path.read_bytes()), unsafe_skip_copy=True
@@ -118,24 +131,23 @@ def extract_func_params(params: cst.Parameters) -> Iterable[Parameter]:
 
 
 class Indexer(cst.CSTVisitor):
-    def __init__(self, scope: str | None = None) -> None:
+    def __init__(self, scope: str, external_symbol_table: SymbolTable) -> None:
         super().__init__()
-        self._scope_name: str | None = scope
+        self._scope_name: str = scope
         self._symbol_table: dict[str, FQName] = {}
+        self._external_symbol_table = external_symbol_table
         self.classes: list[Class] = []
         self.functions: list[Function] = []
         self.variables: list[Variable] = []
         self.documentation: list[Documentation] = []
-        self.exports: list[FQName] = []
+        self.exports: list[tuple[ProjectName | None, FQName]] = []
 
     def leave_Module(self, original_node: cst.Module) -> None:
         vis = GatherExportsVisitor(CodemodContext())
         original_node.visit(vis)
-        # Maybe have an exports section?
-        self.exports.extend(
-            self._symbol_table.get(name, FQName(name))
-            for name in vis.explicit_exported_objects
-        )
+        for name in vis.explicit_exported_objects:
+            fqname = self._symbol_table.get(name, self.scoped_name(name))
+            self.exports.append((self._external_symbol_table.get(fqname), fqname))
 
     def scoped_name(self, name: str) -> FQName:
         if self._scope_name:
@@ -154,8 +166,6 @@ class Indexer(cst.CSTVisitor):
 
         from_mod = ""
         if node.relative:
-            if self._scope_name is None:
-                raise ValueError("Tried relative import when scope name is empty")
             from_mod = self._scope_name.rsplit(".", len(node.relative) - 1)[0] + "."
         if node.module:
             from_mod += get_full_name_for_node(node.module) or ""
@@ -200,7 +210,7 @@ class Indexer(cst.CSTVisitor):
         comments = filter(
             None, (extract_documentation(line) for line in node.leading_lines)
         )
-        indexer = Indexer(scope=my_name)
+        indexer = Indexer(my_name, self._external_symbol_table)
         node.body.visit(indexer)
         self.classes.append(
             Class(
@@ -223,7 +233,7 @@ class Indexer(cst.CSTVisitor):
             None, (extract_documentation(line) for line in node.leading_lines)
         )
         # TODO: this is way too much work for just extracting docs
-        indexer = Indexer(self._scope_name)
+        indexer = Indexer(self._scope_name, self._external_symbol_table)
         node.body.visit(indexer)
 
         params = extract_func_params(node.params)

--- a/py_wtf/indexer/pypi.py
+++ b/py_wtf/indexer/pypi.py
@@ -12,10 +12,34 @@ from packaging.requirements import Requirement
 
 from py_wtf.repository import ProjectRepository
 
-from py_wtf.types import FQName, Project, ProjectMetadata, ProjectName
+from py_wtf.types import FQName, Project, ProjectMetadata, ProjectName, SymbolTable
 from .file import index_dir
 
 logger = logging.getLogger(__name__)
+
+
+def _build_symbol_table(projects: Iterable[Project]) -> SymbolTable:
+    ret: SymbolTable = {}
+    for project in projects:
+        pname = project.name
+        for mod in project.modules:
+            ret[FQName(mod.name)] = pname
+            for _, exp in mod.exports:
+                ret[exp] = pname
+            for func in mod.functions:
+                ret[FQName(func.name)] = pname
+            for var in mod.variables:
+                ret[FQName(var.name)] = pname
+            for cls in mod.classes:
+                ret[FQName(cls.name)] = pname
+                for func in cls.methods:
+                    ret[FQName(func.name)] = pname
+                for var in cls.class_variables:
+                    ret[FQName(var.name)] = pname
+                for var in cls.instance_variables:
+                    ret[FQName(var.name)] = pname
+                # TODO: inner classes and more
+    return ret
 
 
 def index_project(
@@ -30,7 +54,7 @@ def index_project(
             proj = repo.get(name, partial(index_project, repo=repo))
             deps.append(proj)
 
-        modules = list(index_dir(src_dir))
+        modules = list(index_dir(src_dir, _build_symbol_table(deps)))
 
     proj = Project(
         project_name,

--- a/py_wtf/repository.py
+++ b/py_wtf/repository.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Callable, Iterable, NewType
+from typing import Callable, Iterable
 
 from cattrs.preconf.json import make_converter
 

--- a/py_wtf/types.py
+++ b/py_wtf/types.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from dataclasses import dataclass
 from typing import NewType, TYPE_CHECKING
 
@@ -43,7 +41,7 @@ class Class:
     methods: list[Function]
     class_variables: list[Variable]
     instance_variables: list[Variable]
-    inner_classes: list[Class]
+    inner_classes: list["Class"]
     documentation: list[Documentation]
 
 
@@ -54,15 +52,7 @@ class Module:
     functions: list[Function]
     variables: list[Variable]
     classes: list[Class]
-    exports: list[FQName]
-
-
-@dataclass(frozen=True)
-class Project:
-    name: ProjectName
-    metadata: ProjectMetadata
-    documentation: list[Documentation]
-    modules: list[Module]
+    exports: list[tuple[ProjectName | None, FQName]]
 
 
 @dataclass
@@ -74,3 +64,14 @@ class ProjectMetadata:
     documentation_url: str | None
     dependencies: list[str]
     summary: str | None
+
+
+@dataclass(frozen=True)
+class Project:
+    name: ProjectName
+    metadata: ProjectMetadata
+    documentation: list[Documentation]
+    modules: list[Module]
+
+
+SymbolTable = dict[FQName, ProjectName]

--- a/tests/indexer/test_file.py
+++ b/tests/indexer/test_file.py
@@ -4,12 +4,14 @@ from textwrap import dedent
 import pytest
 from py_wtf.indexer import file as mod_under_test
 from py_wtf.indexer.file import index_dir, index_file
-from py_wtf.types import Module
+from py_wtf.types import FQName, Module, ProjectName, SymbolTable
 
-empty_module = Module("testmod", (), (), (), (), ())
+empty_module = Module("testmod", [], [], [], [], [])
 
 
-def mock_index_file(base_dir: Path, path: Path) -> Module:
+def mock_index_file(
+    base_dir: Path, path: Path, symbol_table: SymbolTable | None = None
+) -> Module:
     return empty_module
 
 
@@ -77,10 +79,11 @@ def package_file(tmp_path: Path) -> Path:
     some_file.parent.mkdir()
     code = dedent(
         """
+        from dependencyproject import helper
         def foo(): ...
         bar = 2
 
-        __all__ = ["foo"]
+        __all__ = ["foo", "helper"]
         """
     )
     some_file.write_text(code)
@@ -110,4 +113,23 @@ def test_index_package(package: Module, package_file: Path) -> None:
 
 
 def test_index_package_exports(package: Module) -> None:
-    assert list(package.exports) == ["foo"]
+    assert set(package.exports) == {
+        (None, "dependencyproject.helper"),
+        (None, "mypackage.foo"),
+    }
+
+
+@pytest.fixture
+def package_with_dep(package_file: Path) -> Module:
+    return index_file(
+        package_file.parent.parent,
+        package_file,
+        {FQName("dependencyproject.helper"): ProjectName("dependency")},
+    )
+
+
+def test_index_package_exports_with_dependencies(package_with_dep: Module) -> None:
+    assert set(package_with_dep.exports) == {
+        (None, "mypackage.foo"),
+        ("dependency", "dependencyproject.helper"),
+    }

--- a/tests/indexer/test_pypi.py
+++ b/tests/indexer/test_pypi.py
@@ -9,7 +9,8 @@ from zipfile import ZipFile
 import pytest
 from py_wtf.indexer import pypi as module_under_test
 
-from py_wtf.indexer.pypi import download
+from py_wtf.indexer.pypi import _build_symbol_table, download
+from py_wtf.types import FQName, Project
 
 
 @pytest.fixture(params=[None, ["click (>=8.0.0)", "aiohttp (>=3.7.4) ; extra == 'd'"]])
@@ -102,3 +103,8 @@ def test_download(tmp_path: Path) -> None:
 def test_no_extras_in_deps(tmp_path: Path) -> None:
     _, metadata = download("foo", tmp_path)
     assert "aiohttp" not in metadata.dependencies
+
+
+def test_symbol_table_building(project: Project) -> None:
+    table = _build_symbol_table([project])
+    assert table[FQName("foo")] == "testproject"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #70
* #67
* __->__ #65
* #64
* #63
* #62
* #58

Previously `Module.exports` was just a simple list of names. Now it's a (projectname, fqname) tuple, where `projectname` is the name of the project `fqname` is defined in, or `None` if the indexer can't find it. This can be in two cases:

1. When `fqname` is defined in the same project as the module is in
2. When `fqname` comes from a project that isn't indexed: a standard library, an optional dependency (we only index required deps), or some other indexer error