### PR TITLE
Let there be headers and footers!

### DIFF
--- a/www/components/FetchProject.tsx
+++ b/www/components/FetchProject.tsx
@@ -1,4 +1,3 @@
-import process from "process";
 import React from "react";
 import useSWR from "swr";
 

--- a/www/components/PageLayout.tsx
+++ b/www/components/PageLayout.tsx
@@ -56,15 +56,16 @@ const Content = styled.main`
 `;
 
 export interface Props {
+  title: string;
   children: ReactNode;
 }
 
-export default function PageLayout({ children }: Props) {
+export default function PageLayout({ title, children }: Props) {
   return (
     <ThemeProvider theme={darkTheme}>
       <PageContainer>
         <Head>
-          <title>py.wtf</title>
+          <title>{title}</title>
           {/*<link rel="icon" href="/favicon.ico" /> */}
         </Head>
 

--- a/www/components/PageLayout.tsx
+++ b/www/components/PageLayout.tsx
@@ -1,0 +1,92 @@
+import { ThemeProvider, css } from "@emotion/react";
+import styled from "@emotion/styled";
+import Head from "next/head";
+import { ReactNode } from "react";
+
+import FullPageBackground from "@/components/core/layout/FullPageBackground";
+import { flexColumn, flexColumnCenter } from "@/components/core/layout/helpers";
+import { Link } from "@/components/core/navigation/Link";
+import { darkTheme } from "@/components/core/theme/theme";
+
+import { Text } from "./core/typography/Text";
+
+const PageContainer = styled(FullPageBackground)`
+  max-height: 100vh;
+`;
+
+const frameStyles = css`
+  ${flexColumnCenter}
+  flex-shrink: 0;
+
+  width: 100%;
+  min-height: 30px;
+`;
+
+const Header = styled.header`
+  ${frameStyles}
+
+  border-bottom: 1px solid ${(props) => props.theme.colors.footer.separator};
+`;
+
+const Footer = styled.footer`
+  ${frameStyles}
+
+  border-top: 1px solid ${(props) => props.theme.colors.footer.separator};
+`;
+
+const FrameContent = styled.div`
+  text-align: center;
+
+  padding: ${(props) => props.theme.spacing.m};
+`;
+
+const FrameText = styled(Text)`
+  margin: 0;
+  margin-block-start: 0;
+  margin-block-end: 0;
+`;
+
+const Content = styled.main`
+  ${flexColumn}
+  flex-grow: 1;
+  align-items: center;
+
+  width: 100%;
+  overflow: auto;
+`;
+
+export interface Props {
+  children: ReactNode;
+}
+
+export default function PageLayout({ children }: Props) {
+  return (
+    <ThemeProvider theme={darkTheme}>
+      <PageContainer>
+        <Head>
+          <title>py.wtf</title>
+          {/*<link rel="icon" href="/favicon.ico" /> */}
+        </Head>
+
+        <Header>
+          <FrameContent>
+            <FrameText>Python. Wabbajack Theatrical Fantasy</FrameText>
+          </FrameContent>
+        </Header>
+        <Content>{children}</Content>
+        <Footer>
+          <FrameContent>
+            <FrameText>
+              Footer™: This is a hobby project, please be gentle. Send issues{" "}
+              <Link href="https://github.com/zsol/py.wtf/issues/">here</Link>.
+              Bugs courtesy of{" "}
+              <Link href="https://github.com/abesto">abesto</Link>,{" "}
+              <Link href="https://github.com/anathien">anathien</Link>,{" "}
+              <Link href="https://github.com/zsol">zsol</Link>.
+            </FrameText>
+          </FrameContent>
+        </Footer>
+      </PageContainer>
+    </ThemeProvider>
+  );
+}

--- a/www/components/SPA/ModulePage.tsx
+++ b/www/components/SPA/ModulePage.tsx
@@ -10,6 +10,14 @@ import ContentWithSidebar from "../core/layout/ContentWithSidebar";
 
 export default function ModulePage() {
   const { prj: projectName, mod: modName } = useParams();
+  if (modName === undefined) {
+    return (
+      <div>
+        You did not make a choice, or follow any direction, but now, somehow,
+        you are descending from space ...
+      </div>
+    );
+  }
   return (
     <PageLayout title={`py.wtf: ${modName}`}>
       <FetchProject
@@ -27,7 +35,7 @@ export default function ModulePage() {
               {mod ? (
                 <Module prj={prj} mod={mod} />
               ) : (
-                `Module "${modName || ""}" not found 🤪`
+                `Module "${modName}" not found 🤪`
               )}
             </ContentWithSidebar>
           );

--- a/www/components/SPA/ModulePage.tsx
+++ b/www/components/SPA/ModulePage.tsx
@@ -1,21 +1,17 @@
-import Head from "next/head";
-import React from "react";
 import { useParams } from "react-router-dom";
 
 import Module from "@/components/Docs/Module";
 import FetchProject from "@/components/FetchProject";
 import ModuleList from "@/components/Sidebar/ModuleList";
 
+import PageLayout from "../PageLayout";
 import Sidebar from "../Sidebar/Sidebar";
 import ContentWithSidebar from "../core/layout/ContentWithSidebar";
 
 export default function ModulePage() {
   const { prj: projectName, mod: modName } = useParams();
   return (
-    <>
-      <Head>
-        <title>py.wtf: {modName}</title>
-      </Head>
+    <PageLayout title={`py.wtf: ${modName}`}>
       <FetchProject
         name={projectName}
         content={(prj) => {
@@ -37,6 +33,6 @@ export default function ModulePage() {
           );
         }}
       />
-    </>
+    </PageLayout>
   );
 }

--- a/www/components/SPA/ProjectPage.tsx
+++ b/www/components/SPA/ProjectPage.tsx
@@ -10,10 +10,18 @@ import ContentWithSidebar from "../core/layout/ContentWithSidebar";
 export default function ProjectPage() {
   const { prj } = useParams();
 
+  if (prj === undefined) {
+    return (
+      <div>
+        You did not make a choice, or follow any direction, but now, somehow,
+        you are descending from space ...
+      </div>
+    );
+  }
   return (
     <PageLayout title={`py.wtf: ${prj}`}>
       <FetchProject
-        name={prj as string}
+        name={prj}
         content={(prj) => (
           <ContentWithSidebar sidebar={<Sidebar project={prj} />}>
             <Project prj={prj} />

--- a/www/components/SPA/ProjectPage.tsx
+++ b/www/components/SPA/ProjectPage.tsx
@@ -1,11 +1,9 @@
-import styled from "@emotion/styled";
-import Head from "next/head";
-import React from "react";
 import { useParams } from "react-router-dom";
 
 import Project from "@/components/Docs/Project";
 import FetchProject from "@/components/FetchProject";
 
+import PageLayout from "../PageLayout";
 import Sidebar from "../Sidebar/Sidebar";
 import ContentWithSidebar from "../core/layout/ContentWithSidebar";
 
@@ -13,10 +11,7 @@ export default function ProjectPage() {
   const { prj } = useParams();
 
   return (
-    <>
-      <Head>
-        <title>py.wtf: {prj}</title>
-      </Head>
+    <PageLayout title={`py.wtf: ${prj}`}>
       <FetchProject
         name={prj as string}
         content={(prj) => (
@@ -25,6 +20,6 @@ export default function ProjectPage() {
           </ContentWithSidebar>
         )}
       />
-    </>
+    </PageLayout>
   );
 }

--- a/www/components/SPA/SymbolPage.tsx
+++ b/www/components/SPA/SymbolPage.tsx
@@ -1,5 +1,3 @@
-import Head from "next/head";
-import React from "react";
 import { useParams } from "react-router-dom";
 
 import Class from "@/components/Docs/Class";
@@ -13,6 +11,7 @@ import ModuleList from "@/components/Sidebar/ModuleList";
 import * as docs from "@/lib/docs";
 import { withoutPrefix } from "@/lib/url";
 
+import PageLayout from "../PageLayout";
 import Sidebar from "../Sidebar/Sidebar";
 import ContentWithSidebar from "../core/layout/ContentWithSidebar";
 
@@ -41,12 +40,7 @@ export default function SymbolPage() {
     return <div>Missing "sym" parameter, how did you even get here?</div>;
   }
   return (
-    <>
-      <Head>
-        <title>
-          py.wtf: {modName}.{symName}
-        </title>
-      </Head>
+    <PageLayout title={`py.wtf: ${modName}.${symName}`}>
       <FetchProject
         name={projectName}
         content={(prj) => {
@@ -126,6 +120,6 @@ export default function SymbolPage() {
           );
         }}
       />
-    </>
+    </PageLayout>
   );
 }

--- a/www/components/SPA/SymbolPage.tsx
+++ b/www/components/SPA/SymbolPage.tsx
@@ -36,8 +36,13 @@ function resolveClass(mod: docs.Module, name: string): docs.Class | undefined {
 
 export default function SymbolPage() {
   const { prj: projectName, mod: modName, sym: symName } = useParams();
-  if (symName === undefined) {
-    return <div>Missing "sym" parameter, how did you even get here?</div>;
+  if (symName === undefined || modName === undefined) {
+    return (
+      <div>
+        You did not make a choice, or follow any direction, but now, somehow,
+        you are descending from space ...
+      </div>
+    );
   }
   return (
     <PageLayout title={`py.wtf: ${modName}.${symName}`}>

--- a/www/components/core/layout/ContentWithSidebar.tsx
+++ b/www/components/core/layout/ContentWithSidebar.tsx
@@ -11,7 +11,9 @@ interface Props {
 const Container = styled.div`
   ${flexRow}
 
-  height: 100vh;
+  height: 100%;
+  width: 100%;
+  overflow: hidden;
 `;
 
 const SidebarContainer = styled.div`

--- a/www/components/core/layout/FullPageBackground.tsx
+++ b/www/components/core/layout/FullPageBackground.tsx
@@ -16,6 +16,6 @@ interface Props {
   children: ReactNode;
 }
 
-export default function FullPageBackground({ children }: Props) {
-  return <Container>{children}</Container>;
+export default function FullPageBackground({ children, ...rest }: Props) {
+  return <Container {...rest}>{children}</Container>;
 }

--- a/www/components/core/theme/theme.ts
+++ b/www/components/core/theme/theme.ts
@@ -6,7 +6,11 @@ const colors = {
   },
   white: "#ffffff",
   grey: {
-    light: "#dedede",
+    lightest: "#e9e9e9",
+    light: "#d4d4d4",
+    mid: "#9a9a9a",
+    dark: "#707070",
+    darkest: "#454545",
   },
   cornflower: {
     light: "#9ebcf0",
@@ -44,6 +48,9 @@ export const darkTheme = {
     },
     sidebar: {
       highlight: colors.grey.light,
+    },
+    footer: {
+      separator: colors.grey.darkest,
     },
   },
   spacing: spacing,

--- a/www/pages/_spa.tsx
+++ b/www/pages/_spa.tsx
@@ -1,11 +1,9 @@
-import { ThemeProvider } from "@emotion/react";
 import React from "react";
 import { BrowserRouter, Route, Routes } from "react-router-dom";
 
 import ModulePage from "@/components/SPA/ModulePage";
 import ProjectPage from "@/components/SPA/ProjectPage";
 import SymbolPage from "@/components/SPA/SymbolPage";
-import { darkTheme } from "@/components/core/theme/theme";
 
 import * as spa from "@/lib/spa";
 
@@ -19,14 +17,12 @@ export default function SPAIndex({ router }: Props) {
   spa.receive();
   const Router = router || BrowserRouter;
   return (
-    <ThemeProvider theme={darkTheme}>
-      <Router>
-        <Routes>
-          <Route path="/:prj" element={<ProjectPage />} />
-          <Route path="/:prj/:mod" element={<ModulePage />} />
-          <Route path="/:prj/:mod/:sym" element={<SymbolPage />} />
-        </Routes>
-      </Router>
-    </ThemeProvider>
+    <Router>
+      <Routes>
+        <Route path="/:prj" element={<ProjectPage />} />
+        <Route path="/:prj/:mod" element={<ModulePage />} />
+        <Route path="/:prj/:mod/:sym" element={<SymbolPage />} />
+      </Routes>
+    </Router>
   );
 }

--- a/www/pages/index.tsx
+++ b/www/pages/index.tsx
@@ -2,7 +2,6 @@ import { GetStaticProps } from "next";
 
 import SymbolLinkTable from "@/components/Docs/SymbolLinkTable";
 import PageLayout from "@/components/PageLayout";
-import { flexColumnCenter } from "@/components/core/layout/helpers";
 
 import { Project, getProject, listProjects } from "@/lib/docs";
 import * as url from "@/lib/url";
@@ -30,7 +29,7 @@ export interface Props {
 
 export default function Home({ projects }: Props) {
   return (
-    <PageLayout>
+    <PageLayout title="py.wtf">
       <SymbolLinkTable
         title="Projects"
         url={(prj) => url.project(prj as Project)}

--- a/www/pages/index.tsx
+++ b/www/pages/index.tsx
@@ -1,3 +1,4 @@
+import styled from "@emotion/styled";
 import { GetStaticProps } from "next";
 
 import SymbolLinkTable from "@/components/Docs/SymbolLinkTable";
@@ -5,6 +6,11 @@ import PageLayout from "@/components/PageLayout";
 
 import { Project, getProject, listProjects } from "@/lib/docs";
 import * as url from "@/lib/url";
+
+const ProjectContainer = styled.div`
+  margin-top: auto;
+  margin-bottom: auto;
+`;
 
 export const getStaticProps: GetStaticProps<Props> = async () => {
   const projectNames = await listProjects();
@@ -30,12 +36,14 @@ export interface Props {
 export default function Home({ projects }: Props) {
   return (
     <PageLayout title="py.wtf">
-      <SymbolLinkTable
-        title="Projects"
-        url={(prj) => url.project(prj as Project)}
-        symbols={projects}
-        useReactRouter={false}
-      />
+      <ProjectContainer>
+        <SymbolLinkTable
+          title="Projects"
+          url={(prj) => url.project(prj as Project)}
+          symbols={projects}
+          useReactRouter={false}
+        />
+      </ProjectContainer>
     </PageLayout>
   );
 }

--- a/www/pages/index.tsx
+++ b/www/pages/index.tsx
@@ -1,15 +1,10 @@
-import { ThemeProvider } from "@emotion/react";
-import styled from "@emotion/styled";
 import { GetStaticProps } from "next";
-import Head from "next/head";
 
 import SymbolLinkTable from "@/components/Docs/SymbolLinkTable";
-import FullPageBackground from "@/components/core/layout/FullPageBackground";
+import PageLayout from "@/components/PageLayout";
 import { flexColumnCenter } from "@/components/core/layout/helpers";
-import { Link } from "@/components/core/navigation/Link";
-import { darkTheme } from "@/components/core/theme/theme";
 
-import { Project, ProjectMetadata, getProject, listProjects } from "@/lib/docs";
+import { Project, getProject, listProjects } from "@/lib/docs";
 import * as url from "@/lib/url";
 
 export const getStaticProps: GetStaticProps<Props> = async () => {
@@ -29,47 +24,19 @@ export const getStaticProps: GetStaticProps<Props> = async () => {
     },
   };
 };
-
-const Content = styled.main`
-  ${flexColumnCenter}
-  flex: 1;
-
-  padding: 5rem 0;
-`;
-
-const Footer = styled.footer`
-  ${flexColumnCenter}
-
-  width: 100%;
-  height: 100px;
-
-  border-top: 1px solid #eaeaea;
-`;
-
 export interface Props {
   projects: { name: string; documentation: string[] }[];
 }
 
 export default function Home({ projects }: Props) {
   return (
-    <ThemeProvider theme={darkTheme}>
-      <FullPageBackground>
-        <Head>
-          <title>py.wtf</title>
-          {/*<link rel="icon" href="/favicon.ico" /> */}
-        </Head>
-
-        <Content>
-          <SymbolLinkTable
-            title="Projects"
-            url={(prj) => url.project(prj as Project)}
-            symbols={projects}
-            useReactRouter={false}
-          />
-        </Content>
-
-        <Footer>Footer.</Footer>
-      </FullPageBackground>
-    </ThemeProvider>
+    <PageLayout>
+      <SymbolLinkTable
+        title="Projects"
+        url={(prj) => url.project(prj as Project)}
+        symbols={projects}
+        useReactRouter={false}
+      />
+    </PageLayout>
   );
 }

--- a/www/types/emotion.d.ts
+++ b/www/types/emotion.d.ts
@@ -22,6 +22,9 @@ declare module "@emotion/react" {
       sidebar: {
         highlight: string;
       };
+      footer: {
+        separator: string;
+      };
     };
     spacing: {
       xxs: string;


### PR DESCRIPTION
- Added a `PageLayout` component that takes care of fixed placement headers and footers.
- Wrapped all top level pages into this component
- Magic 🌟 

Index looks:
![image](https://user-images.githubusercontent.com/619826/184978780-b9b415a5-a9ba-4937-ae46-d1b020f33a19.png)

![image](https://user-images.githubusercontent.com/619826/184978900-0b015d9d-c282-4b06-8977-220d3fb74824.png)
