### PR TITLE
fix: handle explicit null project_urls value

### DIFF
--- a/py_wtf/indexer/pypi.py
+++ b/py_wtf/indexer/pypi.py
@@ -165,12 +165,13 @@ async def download(project_name: str, directory: Path) -> Tuple[Path, ProjectMet
         ).json()
         pypi_info = proj_data["info"]
         latest_version = pypi_info["version"]
+        project_urls = pypi_info.get("project_urls") or {}
         proj_metadata = ProjectMetadata(
             latest_version,
             summary=pypi_info.get("summary"),
             home_page=pypi_info.get("home_page"),
             license=pypi_info.get("license"),
-            documentation_url=pypi_info.get("project_urls", {}).get("Documentation"),
+            documentation_url=project_urls.get("Documentation"),
             classifiers=pypi_info.get("classifiers"),
             dependencies=parse_deps(pypi_info.get("requires_dist")),
         )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #92
* #89
* #88
* #90

Handle the case when `pypi_info` explicitly has a `project_urls` field but it's set to `null` in the json.
Like for example for https://pypi.org/pypi/click-didyoumean/json