### PR TITLE
feat: Show stdlib xrefs as links to official docs

### DIFF
--- a/www/__tests__/function.test.tsx
+++ b/www/__tests__/function.test.tsx
@@ -1,0 +1,31 @@
+import "@testing-library/jest-dom";
+
+import { renderSPA, setupSPAServer } from "@/lib/test/spa";
+
+setupSPAServer();
+
+describe("Function page", () => {
+  it("loads and shows correct information", async () => {
+    const { getByRole } = await renderSPA("/project-alpha/alpha.foo/bar");
+
+    // Project heading
+    const heading = getByRole("heading", { name: "Project project-alpha" });
+    expect(heading.children[0]).toHaveAttribute("href", "/project-alpha");
+
+    // Function links, hopefully in the sidebar
+    for (const sym of ["bar", "unzip"]) {
+      expect(getByRole("link", { name: sym })).toHaveAttribute(
+        "href",
+        `/project-alpha/alpha.foo/${sym}`,
+      );
+    }
+  });
+
+  it("shows xrefs to stdlib", async () => {
+    const { getByRole } = await renderSPA("/project-alpha/alpha.foo/bar");
+    expect(getByRole("link", { name: "Generator" })).toHaveAttribute(
+      "href",
+      "//docs.python.org/3/library/typing.html#typing.Generator",
+    );
+  });
+});

--- a/www/lib/url.ts
+++ b/www/lib/url.ts
@@ -44,6 +44,9 @@ export function xref(
   if (project == null) {
     return null;
   }
+  if (project == "__std__") {
+    return stdlibRef(xref.fqname);
+  }
   const lastDot = xref.fqname.lastIndexOf(".");
   if (lastDot === -1) {
     return null;
@@ -51,4 +54,16 @@ export function xref(
   const m = xref.fqname.slice(0, lastDot);
   const s = xref.fqname.slice(lastDot + 1);
   return `/${project}/${m}/${s}`;
+}
+
+export function stdlibRef(fqname: string): string {
+  const lastDot = fqname.lastIndexOf(".");
+  const prefix = "//docs.python.org/3/library";
+  if (lastDot == -1) {
+    return `${prefix}/${fqname}.html`;
+  }
+  // TODO: this doesn't work for things like `concurrent.futures.Executor.submit` where
+  // `m` needs to be `concurrent.futures`
+  const m = fqname.slice(0, lastDot);
+  return `${prefix}/${m}.html#${fqname}`;
 }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #114
* __->__ #113
* #112

When an xref's project field is `__std__`, the frontend now displays a link to docs.python.org.

Some caveats in this implementation:
- Only the latest version of Python 3 docs is shown.
- Links to class fields (methods, variables) are broken.

Fixes #99.