### PR TITLE
feat: Redesign index page

### DIFF
--- a/www/__tests__/index.test.tsx
+++ b/www/__tests__/index.test.tsx
@@ -9,10 +9,12 @@ describe("Index", () => {
     expect(propsResult).toHaveProperty("props");
     const props = (propsResult as { props: Props }).props;
 
-    const { getByRole } = render(<Index {...props} />);
-    const link = getByRole("link", { name: "project-alpha" });
-    expect(link).toBeInTheDocument();
-    expect(link).toHaveAttribute("href", "/project-alpha");
-    expect(link.parentElement).toHaveTextContent("project-alpha");
+    const { getAllByRole } = render(<Index {...props} />);
+    const links = getAllByRole("link", { name: "project-alpha" });
+    links.forEach((link) => {
+      expect(link).toBeInTheDocument();
+      expect(link).toHaveAttribute("href", "/project-alpha");
+      expect(link.parentElement).toHaveTextContent("project-alpha");
+    });
   });
 });

--- a/www/components/Docs/SymbolLinkTable.tsx
+++ b/www/components/Docs/SymbolLinkTable.tsx
@@ -13,7 +13,7 @@ export interface Sym {
   documentation: string[];
 }
 
-interface Props<T extends Sym> {
+export interface SymbolLinkTableProps<T extends Sym> {
   title: string;
   stripPrefix?: string;
   symbols: T[];
@@ -36,7 +36,7 @@ export default function SymbolLinkTable<T extends Sym>({
   symbols,
   url,
   useReactRouter = true,
-}: Props<T>) {
+}: SymbolLinkTableProps<T>) {
   if (symbols.length === 0) {
     return null;
   }

--- a/www/components/Docs/SymbolLinkTable.tsx
+++ b/www/components/Docs/SymbolLinkTable.tsx
@@ -4,7 +4,7 @@ import { sortedBy } from "@/lib/sorting";
 import { withoutPrefix } from "@/lib/url";
 
 import { TBody, Table, Td, Tr } from "../core/layout/CondensedTable";
-import { Link, RouterLink } from "../core/navigation/Link";
+import { RawLink, RouterLink } from "../core/navigation/Link";
 import { H3 } from "../core/typography/Heading";
 import Documentation from "./Documentation";
 
@@ -57,7 +57,7 @@ export default function SymbolLinkTable<T extends Sym>({
                   {useReactRouter ? (
                     <RouterLink to={url(sym)}>{linkText}</RouterLink>
                   ) : (
-                    <Link href={url(sym)}>{linkText}</Link>
+                    <RawLink href={url(sym)}>{linkText}</RawLink>
                   )}
                 </Td>
                 <Td>

--- a/www/components/Header.tsx
+++ b/www/components/Header.tsx
@@ -1,7 +1,7 @@
 import styled from "@emotion/styled";
 
 import { Project } from "@/lib/docs";
-import { generateSearchDescriptors } from "@/lib/searchDescriptor";
+import { generateProjectIndex } from "@/lib/searchDescriptor";
 
 import { Search } from "./core/Search";
 import { flexColumn, flexColumnCenter, flexRow } from "./core/layout/helpers";
@@ -57,7 +57,7 @@ const Header = ({ project, showSearch = true }: HeaderProps) => {
         </HeaderItem>
         {showSearch && project && (
           <HeaderItem width="40%">
-            <Search descriptors={generateSearchDescriptors(project)} />
+            <Search descriptors={generateProjectIndex(project)} />
           </HeaderItem>
         )}
       </HeaderContent>

--- a/www/components/PageLayout.tsx
+++ b/www/components/PageLayout.tsx
@@ -5,7 +5,7 @@ import { ReactNode } from "react";
 
 import FullPageBackground from "@/components/core/layout/FullPageBackground";
 import { flexColumn } from "@/components/core/layout/helpers";
-import { Link } from "@/components/core/navigation/Link";
+import { RawLink } from "@/components/core/navigation/Link";
 import { darkTheme } from "@/components/core/theme/theme";
 
 import {
@@ -58,11 +58,13 @@ export default function PageLayout({ title, header, children }: Props) {
           <FrameContent>
             <FrameText>
               Footer™: This is a hobby project, please be gentle. Send issues{" "}
-              <Link href="https://github.com/zsol/py.wtf/issues/">here</Link>.
-              Bugs courtesy of{" "}
-              <Link href="https://github.com/abesto">abesto</Link>,{" "}
-              <Link href="https://github.com/anathien">anathien</Link>,{" "}
-              <Link href="https://github.com/zsol">zsol</Link>.
+              <RawLink href="https://github.com/zsol/py.wtf/issues/">
+                here
+              </RawLink>
+              . Bugs courtesy of{" "}
+              <RawLink href="https://github.com/abesto">abesto</RawLink>,{" "}
+              <RawLink href="https://github.com/anathien">anathien</RawLink>,{" "}
+              <RawLink href="https://github.com/zsol">zsol</RawLink>.
             </FrameText>
           </FrameContent>
         </Footer>

--- a/www/components/Sidebar/Sidebar.tsx
+++ b/www/components/Sidebar/Sidebar.tsx
@@ -5,7 +5,7 @@ import * as url from "@/lib/url";
 
 import { Project } from "../../lib/docs";
 import { flexColumn } from "../core/layout/helpers";
-import { Link, RouterLink } from "../core/navigation/Link";
+import { RawLink, RouterLink } from "../core/navigation/Link";
 import { H3 } from "../core/typography/Heading";
 import { Text } from "../core/typography/Text";
 
@@ -29,14 +29,14 @@ const SidebarContent = styled.div``;
 export default function Sidebar({ project, children }: Props) {
   const meta = project.metadata;
   const docs_url = meta.documentation_url && (
-    <Link href={meta.documentation_url} target="_blank">
+    <RawLink href={meta.documentation_url} target="_blank">
       <Text>📄 Docs</Text>
-    </Link>
+    </RawLink>
   );
   const home_link = meta.home_page && (
-    <Link href={meta.home_page} target="_blank">
+    <RawLink href={meta.home_page} target="_blank">
       <Text>🏠 Website</Text>
-    </Link>
+    </RawLink>
   );
 
   return (

--- a/www/components/core/Search.tsx
+++ b/www/components/core/Search.tsx
@@ -5,7 +5,7 @@ import { useInRouterContext } from "react-router-dom";
 import { Index, Result, search } from "@/lib/searchDescriptor";
 
 import { flexColumn } from "./layout/helpers";
-import { Link, RouterLink } from "./navigation/Link";
+import { RawLink, RouterLink } from "./navigation/Link";
 
 type SearchParams = {
   descriptors: Index;
@@ -44,7 +44,7 @@ const ItemRouterLink = styled(RouterLink)`
   width: 100%;
 `;
 
-const ItemLink = styled(Link)`
+const ItemLink = styled(RawLink)`
   display: block;
   padding: ${(props) => props.theme.spacing.xs};
 

--- a/www/components/core/Search.tsx
+++ b/www/components/core/Search.tsx
@@ -1,10 +1,11 @@
 import styled from "@emotion/styled";
 import { ReactElement, useEffect, useState } from "react";
+import { useInRouterContext } from "react-router-dom";
 
 import { Index, Result, search } from "@/lib/searchDescriptor";
 
 import { flexColumn } from "./layout/helpers";
-import { RouterLink } from "./navigation/Link";
+import { Link, RouterLink } from "./navigation/Link";
 
 type SearchParams = {
   descriptors: Index;
@@ -36,7 +37,14 @@ const SearchResultItem = styled.div`
   }
 `;
 
-const ItemLink = styled(RouterLink)`
+const ItemRouterLink = styled(RouterLink)`
+  display: block;
+  padding: ${(props) => props.theme.spacing.xs};
+
+  width: 100%;
+`;
+
+const ItemLink = styled(Link)`
   display: block;
   padding: ${(props) => props.theme.spacing.xs};
 
@@ -70,6 +78,7 @@ function Match({ result }: MatchProps): ReactElement {
 export const Search = ({ descriptors }: SearchParams) => {
   const [searchTerm, setSearchTerm] = useState("");
   const [results, setResults] = useState<Array<Result>>([]);
+  const useReactRouter = useInRouterContext();
 
   useEffect(() => {
     // TODO: debounce this
@@ -93,9 +102,15 @@ export const Search = ({ descriptors }: SearchParams) => {
           {results.length > 0 &&
             results.map((result: Result, ind: number) => (
               <SearchResultItem key={`${result.item.name}_${ind}`}>
-                <ItemLink to={`${result.item.url}`}>
-                  <Match result={result} />
-                </ItemLink>
+                {useReactRouter ? (
+                  <ItemRouterLink to={`${result.item.url}`}>
+                    <Match result={result} />
+                  </ItemRouterLink>
+                ) : (
+                  <ItemLink href={`${result.item.url}`}>
+                    <Match result={result} />
+                  </ItemLink>
+                )}
               </SearchResultItem>
             ))}
         </SearchResultContainer>

--- a/www/components/core/navigation/Link.tsx
+++ b/www/components/core/navigation/Link.tsx
@@ -1,7 +1,11 @@
 import styled from "@emotion/styled";
-import { Link as ReactRouterLink } from "react-router-dom";
+import {
+  LinkProps,
+  Link as ReactRouterLink,
+  useInRouterContext,
+} from "react-router-dom";
 
-export const Link = styled.a`
+export const RawLink = styled.a`
   color: ${(props) => props.theme.colors.link.default};
 
   &:hover {
@@ -16,3 +20,11 @@ export const RouterLink = styled(ReactRouterLink)`
     color: ${(props) => props.theme.colors.link.hover};
   }
 `;
+
+export const Link = (props: LinkProps) => {
+  const isReactRouter = useInRouterContext();
+  if (isReactRouter) {
+    return <RouterLink {...props} />;
+  }
+  return <RawLink {...props} href={props.to.toString()} />;
+};

--- a/www/components/core/theme/theme.ts
+++ b/www/components/core/theme/theme.ts
@@ -51,6 +51,7 @@ export const darkTheme = {
       highlight: colors.grey.light,
     },
     footer: {
+      text: colors.grey.dark,
       separator: colors.grey.darkest,
     },
     input: {

--- a/www/lib/docs.ts
+++ b/www/lib/docs.ts
@@ -7,10 +7,12 @@ const indexDirectory = path.join(
   process.env.INDEX_PATH || path.join("public", "_index"),
 );
 
-export async function listProjects(): Promise<string[]> {
-  const entries = await fs.readdir(indexDirectory);
-  const fileNames = entries.filter((fname) => fname.endsWith(".json"));
-  return fileNames.map((f) => f.replace(/\.json$/, ""));
+export async function getIndexMetadata(): Promise<IndexMetadata> {
+  const json = await fs.readFile(
+    path.join(indexDirectory, ".metadata"),
+    "utf8",
+  );
+  return JSON.parse(json) as IndexMetadata;
 }
 
 export async function getProject(name: string): Promise<Project> {
@@ -77,6 +79,7 @@ export type Module = {
 };
 
 export type ProjectMetadata = {
+  name: string;
   version: string;
   classifiers?: Array<string>;
   home_page?: string;
@@ -91,4 +94,11 @@ export type Project = {
   metadata: ProjectMetadata;
   documentation: Array<Documentation>;
   modules: Array<Module>;
+};
+
+export type IndexMetadata = {
+  generated_at: number;
+  latest_projects: Array<ProjectMetadata>;
+  top_projects: Array<ProjectMetadata>;
+  all_project_names: Array<string>;
 };

--- a/www/lib/searchDescriptor.ts
+++ b/www/lib/searchDescriptor.ts
@@ -4,7 +4,13 @@ import memoize from "nano-memoize";
 import { Class, Func, Module, Project, Variable } from "./docs";
 import { mod as generateModuleUrl, symbol as generateSymbolUrl } from "./url";
 
-type SymbolType = "module" | "function" | "variable" | "class" | "export";
+export type SymbolType =
+  | "module"
+  | "function"
+  | "variable"
+  | "class"
+  | "export"
+  | "project";
 
 export type SearchDescriptor = {
   name: string;
@@ -72,19 +78,18 @@ const generateModuleDescriptors = (
   return descriptors;
 };
 
-export const generateSearchDescriptors = memoize((project: Project) => {
-  const options = {
-    keys: ["name"],
-    includeMatches: true,
-  };
+export const generateProjectIndex = memoize((project: Project) => {
   if (!project) {
-    return new Fuse([], options);
+    return makeIndex([]);
   }
 
   // TODO: Think about whether it's a good pattern for this to have a different signature than the rest of the
   // generators.
-  return new Fuse(generateModuleDescriptors(project), options);
+  return makeIndex(generateModuleDescriptors(project));
 });
+
+export const makeIndex = (descriptors: SearchDescriptor[]): Index =>
+  new Fuse(descriptors, { keys: ["name"], includeMatches: true });
 
 export type Index = Fuse<SearchDescriptor>;
 export type Result = Fuse.FuseResult<SearchDescriptor>;

--- a/www/pages/index.tsx
+++ b/www/pages/index.tsx
@@ -35,15 +35,21 @@ const SearchContainer = styled.div`
 
 const ProjectTables = styled.div`
   ${flexRow}
+  // TODO: move this into the theme's breakpoints once they exist
   @media screen and (max-width: 500px) {
-    flex-direction: column;
-    align-items: center;
+    ${flexColumnCenter}
   }
   justify-content: center;
 `;
 
 const ProjectTableWrapper = styled.div`
   max-width: 50%;
+`;
+
+const TimestampFooter = styled.div`
+  ${flexColumnCenter}
+  padding-top: ${(props) => props.theme.spacing.xl};
+  color: ${(props) => props.theme.colors.footer.text};
 `;
 
 function ProjectTable<T extends Sym>(props: SymbolLinkTableProps<T>) {
@@ -53,12 +59,6 @@ function ProjectTable<T extends Sym>(props: SymbolLinkTableProps<T>) {
     </ProjectTableWrapper>
   );
 }
-
-const TimestampFooter = styled.div`
-  ${flexColumnCenter}
-  padding-top: ${(props) => props.theme.spacing.xl};
-  color: ${(props) => props.theme.colors.footer.text};
-`;
 
 interface ProjectSymbol {
   name: string;

--- a/www/pages/index.tsx
+++ b/www/pages/index.tsx
@@ -1,49 +1,137 @@
 import styled from "@emotion/styled";
 import { GetStaticProps } from "next";
 
-import SymbolLinkTable from "@/components/Docs/SymbolLinkTable";
+import SymbolLinkTable, {
+  Sym,
+  SymbolLinkTableProps,
+} from "@/components/Docs/SymbolLinkTable";
 import Header from "@/components/Header";
 import PageLayout from "@/components/PageLayout";
+import { Search } from "@/components/core/Search";
+import {
+  flexColumn,
+  flexColumnCenter,
+  flexRow,
+} from "@/components/core/layout/helpers";
 
-import { Project, getProject, listProjects } from "@/lib/docs";
+import { Project, ProjectMetadata, getIndexMetadata } from "@/lib/docs";
+import {
+  SearchDescriptor,
+  SymbolType,
+  makeIndex,
+} from "@/lib/searchDescriptor";
 import * as url from "@/lib/url";
 
 const ProjectContainer = styled.div`
+  ${flexColumn}
   margin-top: auto;
   margin-bottom: auto;
 `;
 
-export const getStaticProps: GetStaticProps<Props> = async () => {
-  const projectNames = await listProjects();
-  const projects = await Promise.all(
-    projectNames.map(async (name) => {
-      const proj = await getProject(name);
-      return {
-        name,
-        documentation: [`${proj.metadata.summary ?? ""}`],
-      };
-    }),
+const SearchContainer = styled.div`
+  margin: ${(props) => props.theme.spacing.xl};
+  min-width: 40vw;
+`;
+
+const ProjectTables = styled.div`
+  ${flexRow}
+  @media screen and (max-width: 500px) {
+    flex-direction: column;
+    align-items: center;
+  }
+  justify-content: center;
+`;
+
+const ProjectTableWrapper = styled.div`
+  max-width: 50%;
+`;
+
+function ProjectTable<T extends Sym>(props: SymbolLinkTableProps<T>) {
+  return (
+    <ProjectTableWrapper>
+      <SymbolLinkTable {...props} />
+    </ProjectTableWrapper>
   );
+}
+
+const TimestampFooter = styled.div`
+  ${flexColumnCenter}
+  padding-top: ${(props) => props.theme.spacing.xl};
+  color: ${(props) => props.theme.colors.footer.text};
+`;
+
+interface ProjectSymbol {
+  name: string;
+  documentation: string[];
+}
+
+export interface Props {
+  topProjects: ProjectSymbol[];
+  recentProjects: ProjectSymbol[];
+  descriptors: SearchDescriptor[];
+  generatedAt: number;
+}
+
+const metadataToSymbol = (prj: ProjectMetadata) => ({
+  documentation: [prj.summary ?? ""],
+  ...prj,
+});
+
+export const getStaticProps: GetStaticProps<Props> = async () => {
+  const metadata = await getIndexMetadata();
+  const projectNames = metadata.all_project_names;
+  const descriptors = projectNames.map((name) => ({
+    name,
+    type: "project" as SymbolType,
+    url: url.project({ name } as Project),
+  }));
   return {
     props: {
-      projects,
+      topProjects: metadata.top_projects.map(metadataToSymbol),
+      recentProjects: metadata.latest_projects.map(metadataToSymbol),
+      descriptors,
+      generatedAt: metadata.generated_at,
     },
   };
 };
-export interface Props {
-  projects: { name: string; documentation: string[] }[];
+
+function humanizeTime(timestamp: number) {
+  const dt = new Intl.DateTimeFormat(undefined, {
+    timeStyle: "long",
+    dateStyle: "long",
+  });
+  return dt.format(timestamp * 1000);
 }
 
-export default function Home({ projects }: Props) {
+export default function Home({
+  topProjects,
+  recentProjects,
+  descriptors,
+  generatedAt,
+}: Props) {
   return (
     <PageLayout title="py.wtf" header={<Header showSearch={false} />}>
       <ProjectContainer>
-        <SymbolLinkTable
-          title="Projects"
-          url={(prj) => url.project(prj as Project)}
-          symbols={projects}
-          useReactRouter={false}
-        />
+        <SearchContainer>
+          <Search descriptors={makeIndex(descriptors)} />
+        </SearchContainer>
+        <ProjectTables>
+          <ProjectTable
+            title="Top Projects"
+            symbols={topProjects}
+            url={(prj) => url.project(prj as Project)}
+            useReactRouter={false}
+          />
+          <ProjectTable
+            title="Recent Projects"
+            symbols={recentProjects}
+            url={(prj) => url.project(prj as Project)}
+            useReactRouter={false}
+          />
+        </ProjectTables>
+        <TimestampFooter>
+          Generated on {humanizeTime(generatedAt)}
+        </TimestampFooter>
       </ProjectContainer>
     </PageLayout>
   );

--- a/www/types/emotion.d.ts
+++ b/www/types/emotion.d.ts
@@ -23,6 +23,7 @@ declare module "@emotion/react" {
         highlight: string;
       };
       footer: {
+        text: string;
         separator: string;
       };
       input: {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #124
* __->__ #123
* #122
* #121

Instead of listing all the projects, the index page now contains:
- a search bar, which searches in all known project names
- the latest indexed projects and their summaries
- the most popular projects in the index and their summaries
- the timestamp of the index

Closes #73.
Demo video:

https://user-images.githubusercontent.com/66740/188329712-fc22e5aa-ae8a-4afb-bf68-52ed9750662e.mp4

