### PR TITLE
feat: Fix rendering of a unknown RST directives

### DIFF
--- a/py_wtf/indexer/documentation.py
+++ b/py_wtf/indexer/documentation.py
@@ -3,7 +3,7 @@ import re
 from inspect import cleandoc
 from typing import NoReturn
 
-from docutils.nodes import SkipNode, field_list, Node, table
+from docutils.nodes import field_list, Node, SkipNode, table
 from rst_to_myst import markdownit, to_docutils_ast
 from rst_to_myst.mdformat_render import from_tokens
 from rst_to_myst.nodes import EvalRstNode

--- a/py_wtf/indexer/documentation.py
+++ b/py_wtf/indexer/documentation.py
@@ -1,8 +1,12 @@
 import logging
 import re
 from inspect import cleandoc
+from typing import NoReturn
 
-import rst_to_myst
+from docutils.nodes import SkipNode, field_list, Node, table
+from rst_to_myst import markdownit, to_docutils_ast
+from rst_to_myst.mdformat_render import from_tokens
+from rst_to_myst.nodes import EvalRstNode
 
 from py_wtf.types import Documentation, ProjectDescription
 
@@ -25,7 +29,7 @@ def convert_to_myst(src: str | ProjectDescription) -> Documentation:
         text = cleandoc(src)
     if is_rst(text):
         try:
-            text = rst_to_myst.rst_to_myst(text).text
+            text = rst_to_myst(text)
         except Exception:
             logger.exception("Error while parsing RST")
     return Documentation(text)
@@ -33,3 +37,33 @@ def convert_to_myst(src: str | ProjectDescription) -> Documentation:
 
 def is_rst(src: str) -> bool:
     return bool(RST_ROLE.search(src))
+
+
+def rst_to_myst(src: str) -> str:
+    document, warning_stream = to_docutils_ast(
+        src, use_sphinx=True, default_domain="py"
+    )
+    renderer = MarkdownItRenderer(document, warning_stream=warning_stream)
+    output = renderer.to_tokens()
+    myst = from_tokens(output, warning_stream=warning_stream)  # this logs too
+    return myst
+
+
+class MarkdownItRenderer(markdownit.MarkdownItRenderer):
+    def _rst_as_text(self, node: Node) -> NoReturn:
+        text = node.astext()
+        if not text.endswith("\n"):
+            text += "\n"
+        self.add_token("fence", "code", 0, content=text)
+        raise SkipNode
+
+    def visit_field_list(self, node: field_list) -> NoReturn:
+        self._rst_as_text(node)
+
+    def visit_EvalRstNode(self, node: EvalRstNode) -> NoReturn:
+        self._rst_as_text(node)
+
+    def visit_table(self, node: table) -> None:
+        if not self.parse_gfm_table(node):
+            self._rst_as_text(node)
+        self.add_token("table_open", "table", 1)

--- a/tests/indexer/test_documentation.py
+++ b/tests/indexer/test_documentation.py
@@ -49,3 +49,31 @@ def test_description_content_type_rst() -> None:
     assert "like `foo`.\n" == convert_to_myst(
         ProjectDescription(description="like ``foo``.", content_type="text/x-rst")
     )
+
+
+def test_params() -> None:
+    doc = """Initialize a Version object.
+        :param version:
+            The string representation of a version which will be parsed and normalized
+            before use.
+        :raises InvalidVersion:
+            If the ``version`` does not conform to PEP 440 in any way then this
+            exception will be raised."""
+    myst = convert_to_myst(doc)
+    assert "Initialize a Version object" in myst
+    assert "InvalidVersion" in myst
+    assert "The string representation of a version" in myst
+    assert "does not conform to PEP 440" in myst
+    assert "{eval-rst}" not in myst  # this is not supported by the js rendering
+
+
+def test_unknown_directive() -> None:
+    doc = """
+.. testsetup::
+
+    from packaging.specifiers import Specifier, SpecifierSet, InvalidSpecifier
+    from packaging.version import Version
+"""
+    myst = convert_to_myst(doc)
+    assert "from packaging.version import Version" in myst
+    assert "{eval-rst}" not in myst  # this is not supported by the js rendering


### PR DESCRIPTION
Specialize the built-in markdownit renderer to:
1. stop emitting `{eval-rst}` directives which aren't supported by the browser-side myst rendering
2. stop using the deprecated `rawsource` attribute in `field_list` nodes, which is broken. This should make us properly emit `:param foo:` markups which are extremely common.




| Before | After|
|--------|--------|
| ![image](https://github.com/zsol/py.wtf/assets/66740/f408b190-a35d-4834-a9d5-f6709ef59173) | ![image](https://github.com/zsol/py.wtf/assets/66740/79726124-dbf5-485b-8cf2-dd97d9286299) |
| ![image](https://github.com/zsol/py.wtf/assets/66740/1bc230a0-de63-4992-ab5f-4c598d708981) | ![image](https://github.com/zsol/py.wtf/assets/66740/cf37bdd7-8b88-46e0-ba5d-6ca8cb4506b3) |
 