### PR TITLE
feat: search only in local name

### DIFF
--- a/www/components/core/Search.tsx
+++ b/www/components/core/Search.tsx
@@ -57,7 +57,7 @@ function Match({ result }: MatchProps): ReactElement {
   const ret = fuzzysort.highlight(result, highlightCallback) ?? "";
   const parent = result.obj.fqname.slice(
     0,
-    result.obj.fqname.lastIndexOf(`.${result.obj.name}`)
+    result.obj.fqname.lastIndexOf(`.${result.obj.name}`),
   );
   return (
     <>

--- a/www/components/core/Search.tsx
+++ b/www/components/core/Search.tsx
@@ -40,6 +40,7 @@ const SearchResultItem = styled.div`
 const ItemLink = styled(Link)`
   display: block;
   padding: ${(props) => props.theme.spacing.xs};
+  text-decoration: none;
 
   width: 100%;
 `;
@@ -54,7 +55,18 @@ function highlightCallback(highlighted: string, _ind: number): ReactElement {
 
 function Match({ result }: MatchProps): ReactElement {
   const ret = fuzzysort.highlight(result, highlightCallback) ?? "";
-  return <>{ret}</>;
+  const parent = result.obj.fqname.slice(
+    0,
+    result.obj.fqname.lastIndexOf(`.${result.obj.name}`)
+  );
+  return (
+    <>
+      {ret}{" "}
+      <small>
+        (in <em>{parent}</em>)
+      </small>
+    </>
+  );
 }
 
 export const Search = ({ descriptors }: SearchParams) => {

--- a/www/lib/searchDescriptor.ts
+++ b/www/lib/searchDescriptor.ts
@@ -14,6 +14,7 @@ export type SymbolType =
 
 export type SearchDescriptor = {
   name: string;
+  fqname: string;
   type: SymbolType;
   url: string;
 };
@@ -26,8 +27,10 @@ const generateSymbolDescriptors = (
   symbolType: SymbolType,
 ) => {
   symbols.forEach((symbol) => {
+    const parts = symbol.name.split(".");
     descriptors.push({
-      name: symbol.name,
+      name: parts[parts.length - 1],
+      fqname: symbol.name,
       type: symbolType,
       url: generateSymbolUrl(project, module, symbol),
     });
@@ -40,8 +43,10 @@ const generateModuleDescriptors = (
   const descriptors: Array<SearchDescriptor> = [];
 
   project.modules.forEach((module) => {
+    const parts = module.name.split(".");
     descriptors.push({
-      name: module.name,
+      name: parts[parts.length - 1],
+      fqname: module.name,
       type: "module",
       url: generateModuleUrl(project, module),
     });

--- a/www/pages/index.tsx
+++ b/www/pages/index.tsx
@@ -82,6 +82,7 @@ export const getStaticProps: GetStaticProps<Props> = async () => {
   const projectNames = metadata.all_project_names;
   const descriptors = projectNames.map((name) => ({
     name,
+    fqname: name,
     type: "project" as SymbolType,
     url: url.project({ name } as Project),
   }));


### PR DESCRIPTION
feat: search only in local name

Only search in the last part of the fully qualified name of symbols.

Example (from the `packaging` project):
![image](https://github.com/zsol/py.wtf/assets/66740/f19511ca-2019-44e2-ae48-8ae8c20be2c2)
