### PR TITLE
Add more logging

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,6 +26,7 @@ repos:
           - cattrs==22.1.0
           - click>=8.1.3
           - httpx==0.23.0
+          - keke>=0.1.0
           - rich>=12.5.1
           - libcst>=1.1.0
           - trailrunner>=1.2.1

--- a/py_wtf/indexer/file.py
+++ b/py_wtf/indexer/file.py
@@ -7,6 +7,8 @@ from typing import AsyncIterable, cast, Iterable, Protocol
 
 import libcst as cst
 import trailrunner
+
+from keke import ktrace
 from libcst import matchers as m
 from libcst.codemod import CodemodContext
 from libcst.codemod.visitors import GatherExportsVisitor
@@ -23,6 +25,7 @@ from py_wtf.types import (
     Function,
     Module,
     Parameter,
+    ProjectName,
     SymbolTable,
     Type,
     Variable,
@@ -34,7 +37,9 @@ from .annotation import index as extract_type
 logger = logging.getLogger(__name__)
 
 
+@ktrace("_project_name", "dir")
 async def index_dir(
+    _project_name: ProjectName,
     dir: Path,
     symbol_table: SymbolTable | None = None,
     executor: Executor | None = None,

--- a/py_wtf/logging.py
+++ b/py_wtf/logging.py
@@ -15,4 +15,11 @@ def setup_logging(level: int | None = None, to_file: bool = False) -> None:
         dir.mkdir(exist_ok=True, parents=True)
         handler = logging.FileHandler(dir / "indexer.log")
 
-    logging.basicConfig(level=level, handlers=[handler], force=True)
+    logging.basicConfig(
+        level=level,
+        handlers=[handler],
+        force=True,
+        format="[{name}] {message}",
+        style="{",
+    )
+    logging.captureWarnings(True)

--- a/py_wtf/repository.py
+++ b/py_wtf/repository.py
@@ -8,6 +8,7 @@ from time import time
 from typing import AsyncIterable, Callable, Tuple
 
 from cattrs.preconf.json import make_converter
+from keke import ktrace
 
 from py_wtf.types import Index, Project, ProjectMetadata, ProjectName
 
@@ -37,6 +38,7 @@ class ProjectRepository:
         proj = converter.loads(index_contents, Project)
         self._cache[key].set_result(proj)
 
+    @ktrace("project.name")
     def _save(self, project: Project) -> None:
         name = ProjectName(project.name)
         if self._cache[name].done():
@@ -46,6 +48,7 @@ class ProjectRepository:
         index_file = self._index_file(name)
         index_file.write_text(converter.dumps(project))
 
+    @ktrace("key")
     async def get(
         self,
         key: ProjectName,
@@ -68,7 +71,7 @@ class ProjectRepository:
             self._save(project)
 
         if not fut.done():
-            raise ValueError(f"{key} was never yielded by {factory}")
+            raise ValueError(f"{key} was never yielded by factory")
         return fut.result()
 
     def generate_index(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
   "click>=8.1.3",
   "google-cloud-bigquery>=3.23.1",
   "httpx==0.23.0",
+  "keke>=0.1.4",
   "rich>=12.5.1",
   "libcst>=1.1.0",
   "trailrunner>=1.2.1",

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,7 @@
 # - click>=8.1.3
 # - google-cloud-bigquery>=3.23.1
 # - httpx==0.23.0
+# - keke>=0.1.4
 # - libcst>=1.1.0
 # - packaging>=21
 # - rich>=12.5.1
@@ -380,6 +381,9 @@ iniconfig==2.0.0 \
 jinja2==3.1.4 \
     --hash=sha256:4a3aee7acbbe7303aede8e9648d13b8bf88a429282aa6122a993f0ac800cb369 \
     --hash=sha256:bc5dd2abb727a5319567b7a813e6a2e7318c39f4f487cfe6c89c6f9c7d25197d
+keke==0.1.4 \
+    --hash=sha256:a8653b7d9936ddae08d1ea2c298e5e36a50eb379705e3f74ab08b1f6ae3831a0 \
+    --hash=sha256:b16eb1f8dd768747cf55e9e272a02fc642a4a80718ff4feccb5cdcdf9290af0a
 libcst==1.4.0 \
     --hash=sha256:061d6855ef30efe38b8a292b7e5d57c8e820e71fc9ec9846678b60a934b53bbb \
     --hash=sha256:17d71001cb25e94cfe8c3d997095741a8c4aa7a6d234c0f972bc42818c88dfaf \

--- a/tests/indexer/test_file.py
+++ b/tests/indexer/test_file.py
@@ -34,7 +34,9 @@ async def test_index_dir(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Non
 
     some_file = tmp_path / "somefile.py"
     some_file.touch()
-    assert [mod async for mod in index_dir(tmp_path)] == [empty_module]
+    assert [mod async for mod in index_dir(ProjectName("UNUSED"), tmp_path)] == [
+        empty_module
+    ]
 
 
 def test_index_file_syntax_error(tmp_path: Path) -> None:


### PR DESCRIPTION
Add more logging

Add more verbose `logging` logs, as well as a new `--trace` flag to dump chrome traces powered by `keke`.
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/zsol/py.wtf/pull/172).
* #174
* #173
* __->__ #172