### PR TITLE
Update top-pypi-packages filename

### DIFF
--- a/py_wtf/cli/__init__.py
+++ b/py_wtf/cli/__init__.py
@@ -102,7 +102,7 @@ async def index_top_pypi(directory: str, top: int) -> None:
             with attempt:
                 top_pkgs = (
                     await client.get(
-                        "https://hugovk.github.io/top-pypi-packages/top-pypi-packages-30-days.json"
+                        "https://hugovk.github.io/top-pypi-packages/top-pypi-packages.json"
                     )
                 ).json()
         projects: Iterable[str] = (row["project"] for row in top_pkgs["rows"][:top])


### PR DESCRIPTION
To stay within quota, it now has just under 30 days of data, so the filename has been updated. Both will be available for a while. See https://github.com/hugovk/top-pypi-packages/pull/46.