### PR TITLE
Refresh CI and validate the maintenance stack

### DIFF
--- a/.github/workflows/autofixes.yml
+++ b/.github/workflows/autofixes.yml
@@ -3,6 +3,9 @@ name: Applying autofixes
 on:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   fix:
     # Independent bot commits break a stack's linear history.
@@ -11,21 +14,26 @@ jobs:
       !github.event.pull_request.stack &&
       github.actor != 'github-actions[bot]'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.ref }}
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
-      - name: Run Python formatter
-        run: uv run ufmt format
-      - name: Set up nodejs
-        uses: actions/setup-node@v5
+        uses: astral-sh/setup-uv@v10.0.1
         with:
+          version: "0.12.10"
+      - name: Run Python formatter
+        run: uv run --locked ufmt format py_wtf scripts tests
+      - name: Set up nodejs
+        uses: actions/setup-node@v7
+        with:
+          node-version: "24.x"
           cache: "npm"
           cache-dependency-path: "www/package-lock.json"
-      - run: npm install
+      - run: npm ci
         working-directory: www
       - name: Run prettier
         run: npx prettier -w .
@@ -68,6 +76,6 @@ jobs:
           JS
       - name: Commit changes
         if: steps.can-commit.outputs.allowed == 'true'
-        uses: EndBug/add-and-commit@v9
+        uses: EndBug/add-and-commit@v11
         with:
           default_author: github_actions

--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -24,7 +24,7 @@ jobs:
           cache-dependency-path: "www/package-lock.json"
       - run: npm ci
       - run: npm run check-types
-      - run: npm run lint
+      - run: npm run lint -- --max-warnings=0
       - run: npm run test-ci
       - name: Build static site with test fixtures
         run: npm run build

--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -30,3 +30,5 @@ jobs:
         run: npm run build
         env:
           INDEX_PATH: ./__tests__/index
+      - name: Verify exported SPA fallback
+        run: npm run check:export

--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -2,31 +2,31 @@ name: Frontend Tests
 
 on:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
   pull_request:
+
+permissions:
+  contents: read
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        node-version: [18.x]
-
+    defaults:
+      run:
+        working-directory: www
     steps:
-    - uses: actions/checkout@v5
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v5
-      with:
-        node-version: ${{ matrix.node-version }}
-        cache: 'npm'
-        cache-dependency-path: 'www/package-lock.json'
-    - run: npm install
-      working-directory: www
-    - run: npm run check-types
-      working-directory: www
-    - run: npm run lint
-      working-directory: www
-    - run: npm run test-ci
-      working-directory: www
+      - uses: actions/checkout@v7
+      - name: Use Node.js 24
+        uses: actions/setup-node@v7
+        with:
+          node-version: "24.x"
+          cache: "npm"
+          cache-dependency-path: "www/package-lock.json"
+      - run: npm ci
+      - run: npm run check-types
+      - run: npm run lint
+      - run: npm run test-ci
+      - name: Build static site with test fixtures
+        run: npm run build
+        env:
+          INDEX_PATH: ./__tests__/index

--- a/.github/workflows/indexer-tests.yml
+++ b/.github/workflows/indexer-tests.yml
@@ -5,14 +5,32 @@ on:
     branches: ["main"]
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.13", "3.14"]
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v10.0.1
+        with:
+          version: "0.12.10"
+          # Sets UV_PYTHON so nested uv invocations by poe use the matrix version.
+          python-version: ${{ matrix.python-version }}
       - name: Run tests
-        run: uv run poe cov
+        run: uv run --locked poe cov
       - name: Type check
-        run: uv run poe check-types
+        run: uv run --locked poe check-types
+      - name: Check Python formatting
+        run: uv run --locked ufmt check py_wtf scripts tests
+      - name: Verify generated frontend fixtures
+        run: |
+          uv run --locked py-wtf generate-test-index www/__tests__/index
+          git diff --exit-code -- www/__tests__/index
+          test -z "$(git ls-files --others --exclude-standard -- www/__tests__/index)"

--- a/.github/workflows/update-index.yml
+++ b/.github/workflows/update-index.yml
@@ -12,9 +12,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout main
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v10.0.1
+        with:
+          version: "0.12.10"
       - id: auth
         uses: google-github-actions/auth@v3.0.0
         with:
@@ -23,7 +25,7 @@ jobs:
           project_id: pypinfo-214114
           export_environment_variables: true
       - name: Index
-        run: set -x; uv run py-wtf index-since --since "$(date -d '1hour ago' '+%Y-%m-%d %H:%M:%S')" _index
+        run: uv run --locked py-wtf index-since --since "$(date -d '1hour ago' '+%Y-%m-%d %H:%M:%S')" _index
       - name: Compress index
         run: gzip -9 _index/*.json
       - name: Upload

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,27 +16,12 @@ repos:
       - id: generate-test-fixtures
         name: Generate test fixtures
         language: python
-        types_or: [python, json]
-        entry: "python -m py_wtf generate-test-index www/__tests__/index"
+        files: '(\.(py|json|toml)$|^uv\.lock$|^\.python-version$)'
+        entry: "uv run --locked py-wtf generate-test-index www/__tests__/index"
         pass_filenames: false
         require_serial: true
-        additional_dependencies:
-          - aiofiles==0.8.0
-          - appdirs==1.4.4
-          - cattrs==22.1.0
-          - click>=8.1.3
-          - httpx==0.23.0
-          - keke>=0.1.0
-          - libcst>=1.1.0
-          - networkx>=3.3
-          - packaging>=21
-          - pytest
-          - rich>=12.5.1
-          - rst-to-myst[sphinx]==0.4.0
-          - stamina>=24.2.0
-          - trailrunner>=1.2.1
-          - types-aiofiles==0.8.0
-          - types-appdirs==1.4.3
+        additional_dependencies: ["uv==0.12.10"]
 
-default_language_version:
-  python: python3.12
+# pre-commit.ci runs hooks without network access; GitHub Actions verifies fixtures.
+ci:
+  skip: [generate-test-fixtures]

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Run the frontend checks from `www` after `npm ci`:
 
 ```shell
 npm run check-types
-npm run lint
+npm run lint -- --max-warnings=0
 npm run test-ci
 INDEX_PATH=./__tests__/index npm run build
 npm run check:export
@@ -105,12 +105,16 @@ verifies generated fixtures on both Python versions.
 
 The frontend uses Next.js 16, React 19, TypeScript 6.0.3, and ESLint 9. Docstrings
 use a focused parser built on markdown-it's public plugin and token APIs, followed
-by a typed render tree and React rendering. See the
-[MyST renderer and benchmark notes](www/benchmarks/README.md) for supported syntax,
-compatibility details, and reproducible parser measurements. Those local
-microbenchmarks measure parsing rather than end-user page latency. Keep the
-parser and rendering regression tests in `www/__tests__/documentation.test.tsx`
-and `www/__tests__/myst.test.tsx` when changing MyST support.
+by a typed render tree and React rendering. The
+[compatibility audit](www/benchmarks/compatibility.md) documents the legacy
+comparison, CommonMark profile, selected MyST conformance fixtures, rendering
+policies, and supported role/directive registry. Coverage is bounded to this
+docstring renderer; remaining Sphinx and document-building features are listed
+in the audit. The [benchmark notes](www/benchmarks/README.md) provide reproducible
+local measurements of tokenization and tree conversion. Those measurements
+exclude MathML generation, React rendering, network access, and layout, so they
+do not establish end-user page latency. Keep the parser, compatibility, and
+rendering regression suites in `www/__tests__` when changing MyST support.
 
 ## Acknowledgements
 

--- a/README.md
+++ b/README.md
@@ -50,16 +50,55 @@ Just don't.
 
 ## Hacking
 
-Please do. Python 3.13, Node 18.
+Please do. Python 3.13 or 3.14, [uv](https://docs.astral.sh/uv/), and Node 24 LTS
+(24.9 or newer). The default Python version is pinned in `.python-version`.
 
 ```shell
 cd py.wtf
 YOUR_FAVORITE_PROJECT=click
-uv run py-wtf index --project-name $YOUR_FAVORITE_PROJECT www/public/_index/
+uv run --locked py-wtf index --project-name $YOUR_FAVORITE_PROJECT www/public/_index/
 cd www
-npm install
+npm ci
 npm run dev
 ```
+
+Run the Python checks from the repository root:
+
+```shell
+uv run --locked poe cov
+uv run --locked poe check-types
+uv run --locked ufmt check py_wtf scripts tests
+uv run --locked py-wtf generate-test-index www/__tests__/index
+git diff --exit-code -- www/__tests__/index
+```
+
+CI runs these checks on Python 3.13 and 3.14. To select a version locally, set
+`UV_PYTHON=3.13` or `UV_PYTHON=3.14`; this also selects the interpreter for the
+nested uv commands run by poe.
+
+Run the frontend checks from `www` after `npm ci`:
+
+```shell
+npm run check-types
+npm run lint
+npm run test-ci
+INDEX_PATH=./__tests__/index npm run build
+```
+
+The build exports the static site to `www/out`. It uses `www/public/_index` by
+default; `INDEX_PATH=./__tests__/index` selects the checked-in test data instead.
+The commands above use a POSIX shell. In PowerShell, set the build environment
+variable with `$env:INDEX_PATH = './__tests__/index'`, then run `npm run build`.
+
+To install the local hooks, run `uv tool run pre-commit install`. Check all files
+with `uv tool run pre-commit run --all-files`. The fixture hook installs uv and
+uses the project lockfile, including after Python dependency changes. It needs
+network access on its first run, so pre-commit.ci skips that hook; GitHub Actions
+verifies generated fixtures on both Python versions.
+
+The frontend uses Next.js 16 and React 19, with TypeScript 5 and ESLint 9 within
+the supported ranges of its lint plugins. Keep the docstring rendering regression
+tests in `www/__tests__/markdown.test.tsx` when changing MyST support.
 
 ## Acknowledgements
 

--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ npm run check-types
 npm run lint
 npm run test-ci
 INDEX_PATH=./__tests__/index npm run build
+npm run check:export
 ```
 
 The build exports the static site to `www/out`. It uses `www/public/_index` by
@@ -90,15 +91,26 @@ default; `INDEX_PATH=./__tests__/index` selects the checked-in test data instead
 The commands above use a POSIX shell. In PowerShell, set the build environment
 variable with `$env:INDEX_PATH = './__tests__/index'`, then run `npm run build`.
 
+Use `npm run build` (or `npm run export`) to produce the complete static site:
+it preserves `public/404.html` after Next generates its own 404 page. The static
+host serves that fallback for missing routes; it redirects to `/_spa.html`,
+where the original path, query, and hash are restored before hydration.
+`npm run check:export` verifies both scripts in the generated artifacts.
+
 To install the local hooks, run `uv tool run pre-commit install`. Check all files
 with `uv tool run pre-commit run --all-files`. The fixture hook installs uv and
 uses the project lockfile, including after Python dependency changes. It needs
 network access on its first run, so pre-commit.ci skips that hook; GitHub Actions
 verifies generated fixtures on both Python versions.
 
-The frontend uses Next.js 16 and React 19, with TypeScript 5 and ESLint 9 within
-the supported ranges of its lint plugins. Keep the docstring rendering regression
-tests in `www/__tests__/markdown.test.tsx` when changing MyST support.
+The frontend uses Next.js 16, React 19, TypeScript 6.0.3, and ESLint 9. Docstrings
+use a focused parser built on markdown-it's public plugin and token APIs, followed
+by a typed render tree and React rendering. See the
+[MyST renderer and benchmark notes](www/benchmarks/README.md) for supported syntax,
+compatibility details, and reproducible parser measurements. Those local
+microbenchmarks measure parsing rather than end-user page latency. Keep the
+parser and rendering regression tests in `www/__tests__/documentation.test.tsx`
+and `www/__tests__/myst.test.tsx` when changing MyST support.
 
 ## Acknowledgements
 

--- a/www/lib/searchDescriptor.ts
+++ b/www/lib/searchDescriptor.ts
@@ -5,12 +5,7 @@ import { Class, Func, Module, Project, Variable } from "./docs";
 import { mod as generateModuleUrl, symbol as generateSymbolUrl } from "./url";
 
 export type SymbolType =
-  | "module"
-  | "function"
-  | "variable"
-  | "class"
-  | "export"
-  | "project";
+  "module" | "function" | "variable" | "class" | "export" | "project";
 
 export type SearchDescriptor = {
   name: string;

--- a/www/package.json
+++ b/www/package.json
@@ -3,8 +3,9 @@
   "scripts": {
     "bench:myst": "node benchmarks/myst.ts",
     "dev": "next dev",
-    "build": "next build",
-    "export": "next build",
+    "build": "next build && node -e \"require('node:fs').copyFileSync('public/404.html', 'out/404.html')\"",
+    "export": "npm run build",
+    "check:export": "node scripts/check-export.mjs",
     "start": "next start",
     "lint": "eslint .",
     "check-types": "tsc --noEmit",

--- a/www/scripts/check-export.mjs
+++ b/www/scripts/check-export.mjs
@@ -1,0 +1,61 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { runInNewContext } from "node:vm";
+
+const read = (path) => readFileSync(new URL(path, import.meta.url), "utf8");
+const fallback = read("../out/404.html");
+assert.equal(
+  fallback,
+  read("../public/404.html"),
+  "The export must retain the SPA fallback instead of Next's generated 404",
+);
+
+const spa = read("../out/_spa.html");
+const firstScript = spa.match(/<script\b([^>]*)>([\s\S]*?)<\/script>/i);
+assert(
+  firstScript,
+  "The exported SPA shell must contain its restoration script",
+);
+assert(firstScript.index < spa.indexOf("</head>"));
+assert(!/\b(src|async|defer)\b/.test(firstScript[1]));
+
+const redirectScript = fallback.match(/<script\b[^>]*>([\s\S]*?)<\/script>/i);
+assert(redirectScript, "The exported 404 must redirect to the SPA shell");
+
+for (const route of [
+  "/project-alpha",
+  "/project-alpha/alpha.core/Helper?a=1&b=2#definition",
+  "/project-alpha/alpha.foo/unzip?x=1&x=2&encoded=a%26b&plus=a+b#escaped%23hash",
+  "/project%252Fname/module%20name?empty=&literal=~and~#hash",
+]) {
+  const original = new URL(route, "http://localhost:4173");
+  let redirected;
+  runInNewContext(redirectScript[1], {
+    window: {
+      location: {
+        pathname: original.pathname,
+        search: original.search,
+        hash: original.hash,
+        replace: (url) => (redirected = new URL(url, original)),
+      },
+    },
+  });
+  assert(redirected, "The exported 404 must perform a redirect");
+  assert.equal(redirected.origin, original.origin);
+  assert.equal(redirected.pathname, "/_spa.html");
+  let restored;
+  runInNewContext(firstScript[2], {
+    URL,
+    window: {
+      location: redirected,
+      history: { replaceState: (_state, _title, url) => (restored = url) },
+    },
+  });
+  assert.equal(
+    restored,
+    route,
+    "Restore path, query and hash before hydration",
+  );
+}
+
+console.log("Exported 404 and SPA scripts preserve all deep-link round trips.");


### PR DESCRIPTION
Refresh workflows for Python 3.13/3.14 and Node 24, with locked uv environments, npm ci, strict frontend lint, type/test/build checks, and generated-fixture validation. Update pre-commit and document the final toolchain and bounded MyST compatibility.

Fix a production export regression discovered by browser testing: Next overwrites public/404.html with a generic 404 page. Normal build/export now restores the SPA fallback, and check:export verifies the emitted file, script ordering before hydration, and encoded URL round trips.

Validation on the complete stack: clean npm ci; TypeScript 6; strict lint; 1,407 tests in 17 suites; static export and artifact checks; all tracked frontend formatting; full pre-commit including fixture generation; actionlint; npm and locked Python audits with zero known vulnerabilities. Unchanged Python code passed 78 tests on each of Python 3.13 and 3.14 with 71% coverage and clean type/format checks.

Real browser tests against the final exported site rendered function/class deep links while preserving encoded paths, repeated and empty query parameters, plus signs, and fragments. No captured browser errors or warnings. Hosted checks run after publication; local validation was on Windows and loopback.

Final layer of the maintenance stack, based on the reviewed MyST rewrite. Parser compatibility/benchmark evidence and explicit registry limits are linked from README.
